### PR TITLE
Fetch films and fetch article errors fixed

### DIFF
--- a/source/_fetchdir/films_poff/acasa-my-home/data.et.yaml
+++ b/source/_fetchdir/films_poff/acasa-my-home/data.et.yaml
@@ -102,7 +102,7 @@ countriesAndLanguages:
             name: Inglise
 title: 'Acasă, mu kodu'
 slug: acasa-mu-kodu
-directory: source/_fetchdir/films_poff//acasa-my-home
+directory: source/_fetchdir/films_poff/acasa-my-home
 path: film/acasa-mu-kodu
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/acasa-my-home/data.ru.yaml
+++ b/source/_fetchdir/films_poff/acasa-my-home/data.ru.yaml
@@ -81,7 +81,7 @@ countriesAndLanguages:
             name: Английский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//acasa-my-home
+directory: source/_fetchdir/films_poff/acasa-my-home
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/acid/data.et.yaml
+++ b/source/_fetchdir/films_poff/acid/data.et.yaml
@@ -73,7 +73,7 @@ countriesAndLanguages:
             name: Vene
 title: Hape
 slug: hape
-directory: source/_fetchdir/films_poff//acid
+directory: source/_fetchdir/films_poff/acid
 path: film/hape
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/acid/data.ru.yaml
+++ b/source/_fetchdir/films_poff/acid/data.ru.yaml
@@ -61,7 +61,7 @@ countriesAndLanguages:
             name: Русский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//acid
+directory: source/_fetchdir/films_poff/acid
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/banksy-most-wanted/data.et.yaml
+++ b/source/_fetchdir/films_poff/banksy-most-wanted/data.et.yaml
@@ -82,7 +82,7 @@ countriesAndLanguages:
             name: Inglise
 title: 'Tagaotsitav: Banksy!'
 slug: tagaotsitav-banksy
-directory: source/_fetchdir/films_poff//banksy-most-wanted
+directory: source/_fetchdir/films_poff/banksy-most-wanted
 path: film/tagaotsitav-banksy
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/banksy-most-wanted/data.ru.yaml
+++ b/source/_fetchdir/films_poff/banksy-most-wanted/data.ru.yaml
@@ -62,7 +62,7 @@ countriesAndLanguages:
             name: Английский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//banksy-most-wanted
+directory: source/_fetchdir/films_poff/banksy-most-wanted
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/champions/data.et.yaml
+++ b/source/_fetchdir/films_poff/champions/data.et.yaml
@@ -77,7 +77,7 @@ countriesAndLanguages:
             name: Hispaania
 title: Tšempionid
 slug: tsempionid
-directory: source/_fetchdir/films_poff//champions
+directory: source/_fetchdir/films_poff/champions
 path: film/tsempionid
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/champions/data.ru.yaml
+++ b/source/_fetchdir/films_poff/champions/data.ru.yaml
@@ -64,7 +64,7 @@ countriesAndLanguages:
             name: Испанский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//champions
+directory: source/_fetchdir/films_poff/champions
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/final-portrait/data.et.yaml
+++ b/source/_fetchdir/films_poff/final-portrait/data.et.yaml
@@ -95,7 +95,7 @@ countriesAndLanguages:
             name: Prantsuse
 title: Viimane portree
 slug: viimane-portree
-directory: source/_fetchdir/films_poff//final-portrait
+directory: source/_fetchdir/films_poff/final-portrait
 path: film/viimane-portree
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/final-portrait/data.ru.yaml
+++ b/source/_fetchdir/films_poff/final-portrait/data.ru.yaml
@@ -79,7 +79,7 @@ countriesAndLanguages:
             name: Французский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//final-portrait
+directory: source/_fetchdir/films_poff/final-portrait
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/flawless/data.et.yaml
+++ b/source/_fetchdir/films_poff/flawless/data.et.yaml
@@ -102,7 +102,7 @@ countriesAndLanguages:
             name: Vene
 title: Täiuslik
 slug: taiuslik
-directory: source/_fetchdir/films_poff//flawless
+directory: source/_fetchdir/films_poff/flawless
 path: film/taiuslik
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/flawless/data.ru.yaml
+++ b/source/_fetchdir/films_poff/flawless/data.ru.yaml
@@ -89,7 +89,7 @@ countriesAndLanguages:
             name: Русский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//flawless
+directory: source/_fetchdir/films_poff/flawless
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/force-of-habit/data.et.yaml
+++ b/source/_fetchdir/films_poff/force-of-habit/data.et.yaml
@@ -92,7 +92,7 @@ countriesAndLanguages:
             name: Soome
 title: Harjumuse jõud
 slug: harjumuse-joud
-directory: source/_fetchdir/films_poff//force-of-habit
+directory: source/_fetchdir/films_poff/force-of-habit
 path: film/harjumuse-joud
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/force-of-habit/data.ru.yaml
+++ b/source/_fetchdir/films_poff/force-of-habit/data.ru.yaml
@@ -73,7 +73,7 @@ countriesAndLanguages:
             name: Финский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//force-of-habit
+directory: source/_fetchdir/films_poff/force-of-habit
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/house-of-hummingbird/data.et.yaml
+++ b/source/_fetchdir/films_poff/house-of-hummingbird/data.et.yaml
@@ -78,7 +78,7 @@ countriesAndLanguages:
             name: Korea
 title: Hüvasti!
 slug: huvasti
-directory: source/_fetchdir/films_poff//house-of-hummingbird
+directory: source/_fetchdir/films_poff/house-of-hummingbird
 path: film/huvasti
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/house-of-hummingbird/data.ru.yaml
+++ b/source/_fetchdir/films_poff/house-of-hummingbird/data.ru.yaml
@@ -63,7 +63,7 @@ countriesAndLanguages:
             name: Корейский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//house-of-hummingbird
+directory: source/_fetchdir/films_poff/house-of-hummingbird
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/invisible-life-of-euridice-gusmao/data.et.yaml
+++ b/source/_fetchdir/films_poff/invisible-life-of-euridice-gusmao/data.et.yaml
@@ -89,7 +89,7 @@ countriesAndLanguages:
             name: Portugali
 title: Nähtamatu elu
 slug: nahtamatu-elu
-directory: source/_fetchdir/films_poff//invisible-life-of-euridice-gusmao
+directory: source/_fetchdir/films_poff/invisible-life-of-euridice-gusmao
 path: film/nahtamatu-elu
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/invisible-life-of-euridice-gusmao/data.ru.yaml
+++ b/source/_fetchdir/films_poff/invisible-life-of-euridice-gusmao/data.ru.yaml
@@ -77,7 +77,7 @@ countriesAndLanguages:
             name: Португальский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//invisible-life-of-euridice-gusmao
+directory: source/_fetchdir/films_poff/invisible-life-of-euridice-gusmao
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/marcel-duchamp-art-of-the-possible/data.et.yaml
+++ b/source/_fetchdir/films_poff/marcel-duchamp-art-of-the-possible/data.et.yaml
@@ -87,7 +87,7 @@ countriesAndLanguages:
             name: Inglise
 title: Marcel Duchamp ja võimalikkuse kunst
 slug: marcel-duchamp-ja-voimalikkuse-kunst
-directory: source/_fetchdir/films_poff//marcel-duchamp-art-of-the-possible
+directory: source/_fetchdir/films_poff/marcel-duchamp-art-of-the-possible
 path: film/marcel-duchamp-ja-voimalikkuse-kunst
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/marcel-duchamp-art-of-the-possible/data.ru.yaml
+++ b/source/_fetchdir/films_poff/marcel-duchamp-art-of-the-possible/data.ru.yaml
@@ -65,7 +65,7 @@ countriesAndLanguages:
             name: Английский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//marcel-duchamp-art-of-the-possible
+directory: source/_fetchdir/films_poff/marcel-duchamp-art-of-the-possible
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/maudie/data.et.yaml
+++ b/source/_fetchdir/films_poff/maudie/data.et.yaml
@@ -86,7 +86,7 @@ countriesAndLanguages:
             name: Inglise
 title: Maudie
 slug: maudie
-directory: source/_fetchdir/films_poff//maudie
+directory: source/_fetchdir/films_poff/maudie
 path: film/maudie
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/maudie/data.ru.yaml
+++ b/source/_fetchdir/films_poff/maudie/data.ru.yaml
@@ -71,7 +71,7 @@ countriesAndLanguages:
             name: Английский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//maudie
+directory: source/_fetchdir/films_poff/maudie
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/schemers/data.et.yaml
+++ b/source/_fetchdir/films_poff/schemers/data.et.yaml
@@ -80,7 +80,7 @@ countriesAndLanguages:
             name: Inglise
 title: Skeemitajad
 slug: skeemitajad
-directory: source/_fetchdir/films_poff//schemers
+directory: source/_fetchdir/films_poff/schemers
 path: film/skeemitajad
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/schemers/data.ru.yaml
+++ b/source/_fetchdir/films_poff/schemers/data.ru.yaml
@@ -62,7 +62,7 @@ countriesAndLanguages:
             name: Английский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//schemers
+directory: source/_fetchdir/films_poff/schemers
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/self-portrait/data.et.yaml
+++ b/source/_fetchdir/films_poff/self-portrait/data.et.yaml
@@ -77,7 +77,7 @@ countriesAndLanguages:
             name: Norwegian
 title: Autoportree
 slug: autoportree
-directory: source/_fetchdir/films_poff//self-portrait
+directory: source/_fetchdir/films_poff/self-portrait
 path: film/autoportree
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/self-portrait/data.ru.yaml
+++ b/source/_fetchdir/films_poff/self-portrait/data.ru.yaml
@@ -59,7 +59,7 @@ countriesAndLanguages:
             name: Нюнорск (новонорвежский)
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//self-portrait
+directory: source/_fetchdir/films_poff/self-portrait
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/storm-boy/data.et.yaml
+++ b/source/_fetchdir/films_poff/storm-boy/data.et.yaml
@@ -76,7 +76,7 @@ countriesAndLanguages:
             name: Inglise
 title: Tormipoiss
 slug: tormipoiss
-directory: source/_fetchdir/films_poff//storm-boy
+directory: source/_fetchdir/films_poff/storm-boy
 path: film/tormipoiss
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/storm-boy/data.ru.yaml
+++ b/source/_fetchdir/films_poff/storm-boy/data.ru.yaml
@@ -63,7 +63,7 @@ countriesAndLanguages:
             name: Английский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//storm-boy
+directory: source/_fetchdir/films_poff/storm-boy
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/the-goddess-of-fortune/data.et.yaml
+++ b/source/_fetchdir/films_poff/the-goddess-of-fortune/data.et.yaml
@@ -79,7 +79,7 @@ countriesAndLanguages:
             name: Itaalia
 title: Õnnejumalanna
 slug: onnejumalanna
-directory: source/_fetchdir/films_poff//the-goddess-of-fortune
+directory: source/_fetchdir/films_poff/the-goddess-of-fortune
 path: film/onnejumalanna
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/the-goddess-of-fortune/data.ru.yaml
+++ b/source/_fetchdir/films_poff/the-goddess-of-fortune/data.ru.yaml
@@ -65,7 +65,7 @@ countriesAndLanguages:
             name: Итальянский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//the-goddess-of-fortune
+directory: source/_fetchdir/films_poff/the-goddess-of-fortune
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/the-secret-lamb/data.et.yaml
+++ b/source/_fetchdir/films_poff/the-secret-lamb/data.et.yaml
@@ -80,7 +80,7 @@ countriesAndLanguages:
             name: Eesti
 title: Lammas all paremas nurgas
 slug: lammas-all-paremas-nurgas
-directory: source/_fetchdir/films_poff//the-secret-lamb
+directory: source/_fetchdir/films_poff/the-secret-lamb
 path: film/lammas-all-paremas-nurgas
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/the-secret-lamb/data.ru.yaml
+++ b/source/_fetchdir/films_poff/the-secret-lamb/data.ru.yaml
@@ -66,7 +66,7 @@ countriesAndLanguages:
             name: Эстонский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//the-secret-lamb
+directory: source/_fetchdir/films_poff/the-secret-lamb
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/yalda-a-night-for-forgiveness/data.et.yaml
+++ b/source/_fetchdir/films_poff/yalda-a-night-for-forgiveness/data.et.yaml
@@ -120,7 +120,7 @@ countriesAndLanguages:
             name: Pärsia
 title: 'Yalda, andestuse öö'
 slug: yalda-andestuse-oo
-directory: source/_fetchdir/films_poff//yalda-a-night-for-forgiveness
+directory: source/_fetchdir/films_poff/yalda-a-night-for-forgiveness
 path: film/yalda-andestuse-oo
 data:
     pictures: /film_pictures.yaml

--- a/source/_fetchdir/films_poff/yalda-a-night-for-forgiveness/data.ru.yaml
+++ b/source/_fetchdir/films_poff/yalda-a-night-for-forgiveness/data.ru.yaml
@@ -101,7 +101,7 @@ countriesAndLanguages:
             name: Персидский
 title: ''
 slug: ''
-directory: source/_fetchdir/films_poff//yalda-a-night-for-forgiveness
+directory: source/_fetchdir/films_poff/yalda-a-night-for-forgiveness
 path: film/
 data:
     pictures: /film_pictures.yaml

--- a/source/articles.et.yaml
+++ b/source/articles.et.yaml
@@ -10,6 +10,1465 @@
         lastname: Leppik
     created_at: '2020-09-02T07:00:57.082Z'
     updated_at: '2020-09-02T08:01:22.167Z'
+    title_et: Mitte ainult filmid! Tartuff pakub ka põnevaid üritusi
+    slug_et: mitte-ainult-filmid-tartuff-pakub-ka-ponevaid-ueritusi
+    lead_et: >-
+        Mida põnevat võib leida Eesti tänavakunstipealinna Tartu seintelt? Kui
+        levinud on naiste ahistamine Soomes? Milline võiks välja näha
+        hommikupiknik Emajõe lodjal?
+    contents_et: >-
+        Vastused leiate juba 10. augustil Tartus avataval PÖFFi armastusfilmide
+        festivalil Tartuff, mis toob lisaks filmidele huviliste ette rikkaliku
+        ürituste kava.
+
+
+        Mõned nopped:
+
+
+        - duo Maarja Nuut & Ruum annab vabaõhukontserdi, mis avab festivali;
+
+        - Joosep Matjus ja Jaan Tootsen viivad lodjapiknikule mööda Emajõge;
+
+        - kunstirühmituse Ajuokse asutaja Stina Leek korraldab
+        tänavakunstiaktsiooni;
+
+        - tänavakunstifestival Stencibility tutvustab jalgrattatuuridel uuemat
+        ja vanemat tänavakunsti;
+
+        - supilinlane Kadri Kosk avab oma värvilises majas aianäituse ja
+        kodukohviku;
+
+        - Voronja galerii sõidutab enda juurde, kus on avatud näitus „Kättemaks”
+        ja toimub Robert ja Anti Jürjendali kontsert;
+
+        - Loomingu Raamatukogu esitleb Milan Kundera raamatut „Veidrad
+        armastuslood”;
+
+        - Tartu Kunstimuuseum korraldab sümpoosioni „Fotograafia retušeerimata
+        ajalugu”;
+
+        - Eesti dokumentalistide gild tutvustab valmivaid kunstiteemalisi
+        dokumentaalfilme.
+
+        Kokku on üritusi ligemale 30 üle terve Tartu.
+
+
+        Suur osa neist leiab aset festivali klubis, mis kannab nime Pepe´s
+        Bistro & Tartuff Social Club ja asub aadressil Ülikooli 7. Näiteks saab
+        seal kuulata ansambleid Forrest Kämp ja Miré ning osaleda armastuse- ja
+        filmiteemalistel mälumängudel. Samas toimub ka kohtumine festivali
+        külalise, Soome näitleja Suvi Blickiga, kes mängib ahistamist käsitlevas
+        filmis „Harjumuse jõud”.
+
+
+        Festivaliklubi üritused on tasuta, nagu ka kõik Tartus toimuvad
+        filmiseansid.
+
+
+        Ürituste programm valmis koostöös Tartu kunstimuuseumi, Eesti Rahva
+        Muuseumi, Voronja galerii, Tartu Ülikooli semiootika osakonna, Eesti
+        dokumentalistide gildi, Emajõe lodjaseltsi, Loomingu Raamatukogu,
+        Genialistide klubi, Pepe´s Bistro & Social Clubi,
+        tänavakunstifestivaliga Stencibility, kõrgema kunstikooliga Pallas,
+        kirjastusega Loovhoog ning Maarja Nuudi ja Ruumiga.
+
+
+        PÖFFi armastusfilmide festival Tartuff toimub tänavu 10.-15. augustini
+        samaaegselt Tartus ja veebiplatvormil Elisa Stage ning selle alateemaks
+        on kunst.
+    publishFrom: '2020-08-07T09:00:00.000Z'
+    publishUntil: '2021-01-07T10:00:00.000Z'
+    publish_et: true
+    publish_ru: true
+    media:
+        id: 12
+        imageDefault:
+            -
+                id: 32
+                name: F_1_maudie.jpg
+                alternativeText: ''
+                caption: ''
+                width: 1920
+                height: 1080
+                formats:
+                    thumbnail:
+                        ext: .jpg
+                        url: /uploads/thumbnail_F_1_maudie_8754a1bf4d.jpg
+                        hash: thumbnail_F_1_maudie_8754a1bf4d
+                        mime: image/jpeg
+                        name: thumbnail_F_1_maudie.jpg
+                        size: 8.44
+                        width: 245
+                        height: 138
+                hash: F_1_maudie_8754a1bf4d
+                ext: .jpg
+                mime: image/jpeg
+                size: 182.99
+                url: /uploads/F_1_maudie_8754a1bf4d.jpg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-09-01T12:30:02.744Z'
+                updated_at: '2020-09-01T12:30:02.829Z'
+        image_et:
+            -
+                id: 33
+                name: maarjanuut-scaled-2020.jpeg
+                alternativeText: ''
+                caption: ''
+                width: 1067
+                height: 600
+                formats:
+                    thumbnail:
+                        ext: .jpeg
+                        url: >-
+                            /uploads/thumbnail_maarjanuut_scaled_2020_63516cc8aa.jpeg
+                        hash: thumbnail_maarjanuut_scaled_2020_63516cc8aa
+                        mime: image/jpeg
+                        name: thumbnail_maarjanuut-scaled-2020.jpeg
+                        size: 7.51
+                        width: 245
+                        height: 138
+                hash: maarjanuut_scaled_2020_63516cc8aa
+                ext: .jpeg
+                mime: image/jpeg
+                size: 75.64
+                url: /uploads/maarjanuut_scaled_2020_63516cc8aa.jpeg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-09-01T12:44:38.655Z'
+                updated_at: '2020-09-01T12:44:38.738Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    title: test 5 en
+    slug: test-5-en
+    lead: Lead 5 en
+    contents: >-
+        cont 5  encont 5  encont 5  encont 5  encont 5  encont 5  encont 5 
+        encont 5  encont 5  encont 5  encont 5  encont 5  encont 5  encont 5 
+        encont 5  encont 5  encont 5  encont 5  encont 5  encont 5  en
+    publish: true
+    directory: source/_fetchdir/articles_poff/test-5-en
+    path: article/test-5-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 7
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 3
+        firstname: Liis
+        lastname: Käsper
+    created_at: '2020-09-02T07:03:23.979Z'
+    updated_at: '2020-09-03T13:13:24.826Z'
+    title_et: PÖFFi filmitööstusüritus toimub tänavu virtuaalselt
+    slug_et: p-oe-f-fi-filmitoeoestusueritus-toimub-taenavu-virtuaalselt
+    lead_et: >-
+        Pimedate Ööde filmifestivali rahvusvaheline filmivaldkonna
+        professionaalidele suunatud suursündmus Industry@Tallinn & Baltic Event
+        kolib selleks sügiseks veebi.
+    contents_et: >-
+        Põhjuseks on tõenäoliselt ka sügisel kehtivad reisimisega seotud
+        piirangud, mis ei luba suurel osal külalistest Tallinna tulla või seovad
+        siia saabumise liikumisvabaduse kärpimisega.
+
+
+        „Teeme seda raske südamega, aga me ei taha võtta riske,” ütles ürituse
+        juht Marge Liiske. Vastava otsuseni jõuti pärast konsulteerimist
+        terviseametnikega, kelle prognoos ei ennusta sügiseks viiruse vaibumist.
+
+
+        Veebi kolimine annab Liiske sõnul samas võimaluse üritust laiendada ja
+        avab ukse neile, kes ei saaks muidu ajapuudusel või kauguse tõttu
+        Tallinna tulla. Ühtlasi on see hea võimalus katsetada uuenduslikke
+        digitaalseid lahendusi.
+
+
+        Endiselt jätkub valmivate või kavandatavate filmiprojektide vastuvõtt
+        Baltic Evendi kaastootmisturule, filmi- ja telesarjade stsenaariumite
+        võistlusele Script Pool ning Põhja- ja Baltimaade stsenaristide
+        projektitutvustuste foorumile POWR Baltic Stories Exchange. Vastuvõtt
+        lõpeb 21. septembril.
+
+
+        Ürituse delegaatidele ja akrediteeritud välispressile garanteeritakse
+        ligipääs üritustele ja Pimedate Ööde filmifestivali kavas olevatele
+        filmidele.
+
+
+        Industry@Tallinn & Baltic Evendi programmi kuuluvad veel seminarid,
+        õpikojad, meistriklassid ja vestlusringid, mis käsitlevad filmitööstuse
+        ja teleturu aktuaalseid teemasid. Samuti leiab esimest korda aset PÖFFi
+        Akadeemia, kus saavad end täiendada filmindusega seotud erialade
+        esindajad alates näitlejatest ja lõpetades heliloojatega.
+
+
+        Programmi esimesed üritused ja esinejad avalikustab Industry@Tallinn &
+        Baltic Event septembris.
+
+
+        Pimedate Ööde filmifestival leiab tänavu aset 13.–29. novembrini.
+        Koroonaviiruse levikust tulenevalt on ette valmistamisel mitu võimalikku
+        stsenaariumit, sealhulgas toimumist hübriidfestivalina või halvimal
+        juhul tervenisti virtuaalsel kujul.
+    publishFrom: '2020-08-17T09:00:00.000Z'
+    publishUntil: '2020-12-17T10:00:00.000Z'
+    publish_et: false
+    publish_ru: false
+    media:
+        id: 14
+        imageDefault:
+            -
+                id: 31
+                name: Industry_2020_online_news.jpeg
+                alternativeText: ''
+                caption: ''
+                width: 900
+                height: 600
+                formats:
+                    thumbnail:
+                        ext: .jpeg
+                        url: >-
+                            /uploads/thumbnail_Industry_2020_online_news_b73f02f092.jpeg
+                        hash: thumbnail_Industry_2020_online_news_b73f02f092
+                        mime: image/jpeg
+                        name: thumbnail_Industry_2020_online_news.jpeg
+                        size: 15.09
+                        width: 234
+                        height: 156
+                hash: Industry_2020_online_news_b73f02f092
+                ext: .jpeg
+                mime: image/jpeg
+                size: 136.1
+                url: /uploads/Industry_2020_online_news_b73f02f092.jpeg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-09-01T12:27:06.584Z'
+                updated_at: '2020-09-01T12:27:06.648Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    title: test7 en
+    slug: test7-en
+    lead: lead 7 en
+    contents: cont 7 en
+    publish: false
+    directory: source/_fetchdir/articles_poff/test7-en
+    path: article/test7-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 2
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 6
+        firstname: Jaan
+        lastname: Leppik
+    created_at: '2020-09-02T06:22:29.284Z'
+    updated_at: '2020-09-02T08:11:15.785Z'
+    title_et: Tartuffi esimene film on seksuaalsest ahistamisest
+    slug_et: tartuffi-esimene-film-on-seksuaalsest-ahistamisest
+    lead_et: >-
+        PÖFFi armastusfilmide festival Tartuff kuulutas välja esimese linateose,
+        mille teema on hetkel üliaktuaalne – seksuaalne ahistamine.
+    contents_et: >-
+        „Harjumuse jõud” (originaalis „Tottumiskysymys”) koosneb kuuest
+        absurdihuumoriga vürtsitatud loost, mis on inspireeritud igapäevastest
+        naiste avaliku või varjatud diskrimineerimise viisidest.
+
+
+        „Kui te ei ole veel aru saanud, mida taotleb #MeToo, vaadake seda
+        filmi,” soovitab ajaleht Helsingin Sanomat, nimetades „Harjumuse jõudu”
+        eelmise aasta olulisimaks Soome linateoseks.
+
+
+        Patriarhaalse ühiskonna käitumismustreid avav draamakomöödia põhineb
+        populaarsel lühifilmide sarjal „Üksikjuhtum”, mis on Soome veebi-TVs Yle
+        Areena kogunud üle miljoni vaatamiskorra.
+
+
+        Soome noorema ja keskmise põlve naisrežissööride jõudemonstratsiooniks
+        nimetatava filmi on kirjutanud ja lavastanud Kirsikka Saari, Elli
+        Toivoniemi, Anna Paavilainen, Alli Haapasalo, Reetta Aalto, Jenni
+        Toivoniemi ja Miia Tervo. Mängivad Soome tippnäitlejad eesotsas Krista
+        Kosoneni ja Johannes Holopaineniga.
+
+
+        Autorite enda sõnul ei ole filmi ajendiks niivõrd seksuaalne ahistamine,
+        kuivõrd see, kuidas ühiskond seda normaalseks peab.
+
+
+        Soome filmiauhinnale Jussi kandideerib “Harjumuse jõud” parima filmi,
+        režii, stsenaariumi ja meeskõrvalosa kategoorias. Linateose
+        rahvusvaheline esilinastus oli tänavusel Göteborgi filmifestivalil.
+
+
+        Tartuff leiab tänavu aset 10.–15. augustini, kui Tartu Raekoja platsist
+        saab taas Eesti suurim vabaõhukino. Esimest korda avab festival ka
+        virtuaalse kinosaali, mida saab külastada üle kogu Eesti.
+
+
+        Kogu programmi avalikustab festival juuli lõpus.
+
+
+        Tartuffi korraldab Pimedate Ööde filmifestival koostöös Tartu linna,
+        Tartu filmifondi ja Tartu loomemajanduskeskusega.
+    publishFrom: '2020-07-07T09:00:00.000Z'
+    publishUntil: '2021-01-14T10:00:00.000Z'
+    publish_et: true
+    publish_ru: true
+    media:
+        id: 9
+        imageDefault:
+            -
+                id: 35
+                name: F_1_force_of_habit.jpg
+                alternativeText: ''
+                caption: ''
+                width: 1920
+                height: 1080
+                formats:
+                    thumbnail:
+                        ext: .jpg
+                        url: /uploads/thumbnail_F_1_force_of_habit_9bdbea96b7.jpg
+                        hash: thumbnail_F_1_force_of_habit_9bdbea96b7
+                        mime: image/jpeg
+                        name: thumbnail_F_1_force_of_habit.jpg
+                        size: 9
+                        width: 245
+                        height: 138
+                hash: F_1_force_of_habit_9bdbea96b7
+                ext: .jpg
+                mime: image/jpeg
+                size: 277.58
+                url: /uploads/F_1_force_of_habit_9bdbea96b7.jpg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-09-02T08:11:05.707Z'
+                updated_at: '2020-09-02T08:11:05.787Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    title: test 2 en
+    slug: test-2-en
+    lead: lead 2 en
+    contents: cont 2 en
+    publish: true
+    directory: source/_fetchdir/articles_poff/test-2-en
+    path: article/test-2-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 3
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 6
+        firstname: Jaan
+        lastname: Leppik
+    created_at: '2020-09-02T06:23:30.743Z'
+    updated_at: '2020-09-02T08:07:38.360Z'
+    title_et: Tartuff on pühendatud kunstile
+    slug_et: tartuff-on-puehendatud-kunstile
+    lead_et: >-
+        PÖFFi armastusfilmide festival Tartuff pöörab tänavu erilist tähelepanu
+        kunstile.
+    contents_et: >-
+        Kunstimaailma Robin Hood ehk Banksy, Marcel Duchamp, Alberto Giacometti,
+        Kanada naivist Maud Lewis – neist kõnelevad mängu- ja dokumentaalfilmid
+        jõuavad lisaks traditsioonilistele armastusfilmidele ekraanile 10.-15.
+        augustini Tartus.
+
+
+        Tartuffi juhi Kristiina Reidolvi sõnul pole kunsti teema aktuaalne mitte
+        ainult Tartu kui kunstilinna traditsioonide ja ümmarguste tähtpäevade
+        tõttu – Pallas sai mullu saja- ja Tartu kunstimuuseum saab tänavu
+        80-aastaseks -, vaid hoopis laiemas tähenduses.
+
+
+        „Tahame festivaliga tõsta fookusesse kunsti sotsiaalse rolli nii
+        ühiskondlike protsesside käivitaja kui filosoofiliste mõttepiiride
+        nihutajana. Tartu valmistub saama Euroopa kultuuripealinnaks ja selle
+        sotsiaalselt ning ökoloogiliselt vastutustundlik lipukiri „Ellujäämise
+        kunstid” on praegu aktuaalsem kui kunagi varem,” ütles ta.
+
+
+        Kunstiprogrammi avab värske, maailmas vaid mõnel korral linastatud
+        dokumentaalfilm „Tagaotsitav: Banksy!”. Aurélia Rouvieri ja Seamus Haley
+        linateos uurib, kes varjab ennast Banksy nime taga ja miks ta ei taha
+        oma identiteeti paljastada. Vaataja ees avaneb Robin Hoodina tegutseva
+        erakordselt tundliku sotsiaalse närviga tänavakunstniku kaasahaarav
+        portree. Film esilinastus maikuus USAs mainekal Tribeca festivalil.
+
+
+        1964. aastal palus Alberto Giacometti enesele poseerida kriitik James
+        Lordil. Pingeline sessioon kestis kokku 18 päeva, mille jooksul avanes
+        Lordil võimalus heita pilk ühe 20. sajandi kõige olulisema skulptori
+        loomingu kulisside taha, elada kaasa tema siseheitlustele. Stanley Tucci
+        mängufilmi „Viimane portree” aluseks on seesama sessioon, mille
+        tulemusena valmis vähem kui kaks aastat hiljem surnud kunstniku
+        viimaseid meistriteoseid. Giacometti rollis näeme Oscari-võitjast
+        austraallast Geoffrey Rushi.
+
+
+        Aisling Walshi mängufilm „Maudie” on meie esimene põhjalikum tutvus
+        Kanada naivistliku kunstniku Maud Lewisega (1903-1970), kes vaatamata
+        oma artriidist moonutatud liigestele maalis harvanähtava entusiasmiga
+        lilli, loomi ja liblikaid – nendega oli kaetud ka tema imeväike maja,
+        kus ta oma abikaasaga äärmiselt vaeselt elas. Pärast nende surma hoone
+        restaureeriti ja seda saab praegu näha Nova Scotia Kunstigaleriis.
+        Lewist mängib Sally Hawkins, kes on võitnud selle osatäitmise eest ka
+        hulk auhindu. Tema abikaasat kehastab Ethan Hawke.
+
+
+        Ühest 20. sajandi olulisemast kunstnikust Marcel Duchampist, tema
+        pärandist ja mõjust annab põhjaliku ülevaate Matthew Taylori
+        dokumentaalfilm „Marcel Duchamp ja võimalikkuse kunst”. Kunstniku
+        loomingut mõtestavad Jeff Koons, Marina Abramović, David Bowie ja paljud
+        teised suurnimed.
+
+
+        Kõik filmid linastuvad Eestis esimest korda.
+
+
+        Lisaks filmiseanssidele leiab Tartus aset hulk kunstiteemalisi üritusi
+        alates näitustest ja performance´itest ning lõpetades sümpoosionide ja
+        ekskursioonidega. Ürituste programm valmib koostöös Tartu
+        kunstimuuseumi, kõrgema kunstikooliga Pallas, Eesti Rahva Muuseumi,
+        Voronja galerii, tänavakunstifestivaliga Stencibility ja paljude
+        teistega.
+
+
+        Ka festivali plakati autoriteks on Pallase tudengid Anett Tõnismäe ja
+        Emilia Valgiste.
+
+
+        Mullu oli Tartuffi keskmes muusika, tunamullu kirjandus.
+
+
+        15. PÖFFi armastusfilmide festival leiab aset 10.–15. augustini, kui
+        Tartu Raekoja platsist saab taas Eesti suurim vabaõhukino. Dokumentaal-
+        ja lastefilmid linastuvad Athena keskuses. Kõik seansid on
+        traditsiooniliselt tasuta.
+
+
+        Esimest korda avab Tartuff ka virtuaalse kinosaali, mida saab külastada
+        üle kogu Eesti. Elisa Stage´i veebiplatvormi kaudu jõuab vaatajani suur
+        osa Tartuffi filmidest. Virtuaalsetele seanssidele tuleb osta pilet.
+
+
+        Kogu programmi avalikustab festival juuli lõpus.
+
+
+        Tartuffi korraldab Pimedate Ööde filmifestival koostöös Tartu linna,
+        Tartu filmifondi ja Tartu loomemajanduskeskusega.
+    publishFrom: '2020-07-15T09:00:00.000Z'
+    publishUntil: '2021-01-07T10:00:00.000Z'
+    publish_et: true
+    publish_ru: true
+    media:
+        id: 10
+        imageDefault:
+            -
+                id: 34
+                name: banksy_scaled.jpeg
+                alternativeText: ''
+                caption: ''
+                width: 1069
+                height: 600
+                formats:
+                    thumbnail:
+                        ext: .jpeg
+                        url: /uploads/thumbnail_banksy_scaled_178b048e4a.jpeg
+                        hash: thumbnail_banksy_scaled_178b048e4a
+                        mime: image/jpeg
+                        name: thumbnail_banksy_scaled.jpeg
+                        size: 6.62
+                        width: 245
+                        height: 138
+                hash: banksy_scaled_178b048e4a
+                ext: .jpeg
+                mime: image/jpeg
+                size: 68.06
+                url: /uploads/banksy_scaled_178b048e4a.jpeg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-09-02T08:07:24.614Z'
+                updated_at: '2020-09-02T08:07:24.707Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    title: test 3 en
+    slug: test-3-en
+    lead: lead 3 en
+    contents: cont 3 en
+    publish: true
+    directory: source/_fetchdir/articles_poff/test-3-en
+    path: article/test-3-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 6
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 3
+        firstname: Liis
+        lastname: Käsper
+    created_at: '2020-09-02T07:02:01.637Z'
+    updated_at: '2020-09-03T13:24:37.925Z'
+    title_et: Tartuffi filmid jõuavad ekraanile ka Tallinnas
+    slug_et: tartuffi-filmid-jouavad-ekraanile-ka-tallinnas
+    lead_et: >-
+        Tartus jätkuva PÖFFi armastusfilmide festivali Tartuff filme saab
+        vaadata ka järgmisel nädalal Tallinnas, kui Filmimuuseum näitab
+        festivali valikkava.
+    contents_et: >-
+        19.–22. augustini linastuvad Maarjamäel asuva Filmimuuseumi kinos
+        Hispaania režissööri Javier Fesseri komöödia „Tšempionid”, Lõuna-Korea
+        režissööri Bora Kimi draama „Hüvasti!”, Iiri režissööri Aisling Walshi
+        biograafiline draama „Maudie” ja Brasiilia režissööri Karim Aïnouzi
+        melodraama „Nähtamatu elu”.
+
+
+        „Valisime Tartuffi programmist näitamiseks filmid, mis tutvustavad
+        erinevaid filmikultuure ja viivad erinevatesse ajastutesse. Kõik filmid
+        on äratanud tähelepanu tippfestivalidel või veel parem – oma maa
+        vaatajate seas,” ütles Filmimuuseumi kuraator Karlo Funk.
+
+
+        „Tšempionid” on südamlik komöödia vaimupuudega inimestest, kes hakkavad
+        professionaalse treeneri käe all korvpalli mängima. Linateos võitis
+        aasta parima Hispaania filmi auhinna ja esindas Hispaaniat ka
+        mitteingliskeelsete filmide Oscari konkurentsis. Seansi juhatab sisse
+        Hispaania Maja juht Neftali Peral Joris.
+
+
+        Brasiilia rohkelt auhinnatud troopilises melodraamas „Nähtamatu elu”
+        surub ühiskonna konservatiivsus alla kahe õe unistused. Brasiilia esitas
+        filmi ka Oscarile. Seansi juhatab sisse režissöör Kadri Kõusaar, kes on
+        ise Lõuna-Ameerikas filminud.
+
+
+        14-aastane üksildane Seouli tüdruk Eun-hee otsib filmis „Hüvasti!”
+        mõistmist, millest ta on ilma jäetud nii kodus kui koolis. Tegu on
+        tänavuse Tartuffi tunnustatuima linateosega, mis on võitnud ligemale 30
+        auhinda. Seansi juhatab sisse Lõuna-Korea kultuuri uurija Maari
+        Hinsberg.
+
+
+        „Maudie” on erakordne lugu artriidihaigest ühiskonnaheidikust, kes leiab
+        ennast kunsti kaudu. Film põhineb Kanada naivistliku kunstniku Maud
+        Lewise (1903-1970) elul. Teda mängib Sally Hawkins, kes on võitnud selle
+        osatäitmise eest ka hulk auhindu.
+
+
+        Seansid algavad kell 19 ja pilet maksab viis eurot. Filmidel on
+        eestikeelsed subtiitrid. Piletid on saadaval Fientas.
+
+
+        PÖFFi armastusfilmide festival Tartuff kestab 10.–15. augustini.
+        Festivali virtuaalses kinos Elisa Stage saab filme vaadata 16.
+        augustini.
+    publishFrom: '2020-09-24T05:30:00.000Z'
+    publishUntil: '2019-12-31T22:00:00.000Z'
+    publish_et: true
+    publish_ru: false
+    media:
+        id: 13
+        imageDefault:
+            -
+                id: 2
+                name: F_3_invisible_life.jpg
+                alternativeText: ''
+                caption: ''
+                width: 1920
+                height: 1080
+                formats:
+                    large:
+                        ext: .jpg
+                        url: /uploads/large_F_3_invisible_life_fb118ee4f7.jpg
+                        hash: large_F_3_invisible_life_fb118ee4f7
+                        mime: image/jpeg
+                        name: large_F_3_invisible_life.jpg
+                        size: 53.41
+                        width: 1000
+                        height: 563
+                    small:
+                        ext: .jpg
+                        url: /uploads/small_F_3_invisible_life_fb118ee4f7.jpg
+                        hash: small_F_3_invisible_life_fb118ee4f7
+                        mime: image/jpeg
+                        name: small_F_3_invisible_life.jpg
+                        size: 15.85
+                        width: 500
+                        height: 281
+                    medium:
+                        ext: .jpg
+                        url: /uploads/medium_F_3_invisible_life_fb118ee4f7.jpg
+                        hash: medium_F_3_invisible_life_fb118ee4f7
+                        mime: image/jpeg
+                        name: medium_F_3_invisible_life.jpg
+                        size: 30.86
+                        width: 750
+                        height: 422
+                    thumbnail:
+                        ext: .jpg
+                        url: /uploads/thumbnail_F_3_invisible_life_fb118ee4f7.jpg
+                        hash: thumbnail_F_3_invisible_life_fb118ee4f7
+                        mime: image/jpeg
+                        name: thumbnail_F_3_invisible_life.jpg
+                        size: 5.62
+                        width: 245
+                        height: 138
+                hash: F_3_invisible_life_fb118ee4f7
+                ext: .jpg
+                mime: image/jpeg
+                size: 122.39
+                url: /uploads/F_3_invisible_life_fb118ee4f7.jpg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-08-13T19:16:16.284Z'
+                updated_at: '2020-08-13T19:16:16.529Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    tag_premiere_types:
+        - World Premiere
+    tag_programmes:
+        - Official Selection
+    tag_genres:
+        - Animation
+    tag_keywords:
+        - MeToo
+        - Society
+    title: test 6 en
+    slug: test-6-en
+    lead: lead 6 en
+    contents: cont 6 en
+    publish: false
+    directory: source/_fetchdir/articles_poff/test-6-en
+    path: article/test-6-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 4
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 6
+        firstname: Jaan
+        lastname: Leppik
+    created_at: '2020-09-02T06:24:45.587Z'
+    updated_at: '2020-09-02T08:21:08.339Z'
+    title_et: Tartu armastusfilmide festivali avab troopiline melodraama
+    slug_et: test-4-et
+    lead_et: >-
+        **PÖFFi armastusfilmide festival Tartuff** kuulutas väljatänavuse
+        avafilmi, milleks on brasiillase Karim Aïnouzi rohkelt auhinnatud
+        „Nähtamatu elu”.
+    contents_et: >-
+        End troopiliseks melodraamaks nimetav linateos räägib kahest üksteisega
+        kokku kasvanud õest 1950ndate aastate Rio de Janeiros. Konservatiivne
+        isa ja patriarhaalne ühiskond kisuvad nad lahku ega luba täita oma
+        unistusi, kuid nad ei kaota kõigele vaatamata lootust.
+
+
+        Režissöör pühendab oma filmi kõigile neile naistele, kellest Brasiilia
+        ühiskond on kaua mööda vaadanud, neid nähtamatuks pidades.
+
+
+        „See on sedasorti armastuslugu, mida saab harva kinoekraanil näha –
+        tõeline pärl,” kirjutab USA juhtivaid meelelahutustööstuse väljaandeid
+        The Wrap. 
+
+
+        (<iframe width="500" height="281"
+        src="https://www.youtube.com/embed/8fBBGRT9ga0" frameborder="0"
+        allow="accelerometer; autoplay; encrypted-media; gyroscope;
+        picture-in-picture" allowfullscreen></iframe>)
+
+
+        ```<iframe width="500" height="281"
+        src="https://www.youtube.com/embed/8fBBGRT9ga0" frameborder="0"
+        allow="accelerometer; autoplay; encrypted-media; gyroscope;
+        picture-in-picture" allowfullscreen></iframe>```
+
+
+        Film võitis mainekal Cannes´i festivalil kõrvalvõistlusprogrammi „Un
+        Certain Regard” ja Brasiilia esitas selle mitteingliskeelsete filmide
+        Oscarile. USA filmiorganisatsiooni The National Board of Review
+        hinnangul on tegu 2019. aasta ühe kõige huvitavama mitteingliskeelse
+        mängufilmiga. 
+
+
+        Linateos põhineb Martha Batalha romaanil „Eurídice Gusmão nähtamatu
+        elu”. Peaosades Carol Duarte ja Julia Stockler. 
+
+
+        „Nähtamatu elu” jõuab ekraanile 10. augustil Tartu Raekoja platsil,
+        samuti saab seda vaadata Tartuffi virtuaalses kinosaalis Elisa Stage.
+
+
+        Kogu kava avalikustab festival juuli lõpus.
+
+
+        **15. PÖFFi armastusfilmide festival Tartuff** leiab tänavu aset 10.-15.
+        augustini Tartus ja virtuaalselt üle kogu Eesti. Festivali korraldab
+        Pimedate Ööde filmifestival koostöös Tartu linna, Tartu filmifondi ja
+        [](https://lmk.ee). 
+    publishFrom: '2020-07-22T09:00:00.000Z'
+    publishUntil: '2021-01-06T10:00:00.000Z'
+    publish_et: true
+    publish_ru: true
+    media:
+        id: 11
+        imageDefault:
+            -
+                id: 3
+                name: F_2_invisible_life.jpg
+                alternativeText: ''
+                caption: ''
+                width: 1920
+                height: 1080
+                formats:
+                    large:
+                        ext: .jpg
+                        url: /uploads/large_F_2_invisible_life_feb5451063.jpg
+                        hash: large_F_2_invisible_life_feb5451063
+                        mime: image/jpeg
+                        name: large_F_2_invisible_life.jpg
+                        size: 89.02
+                        width: 1000
+                        height: 563
+                    small:
+                        ext: .jpg
+                        url: /uploads/small_F_2_invisible_life_feb5451063.jpg
+                        hash: small_F_2_invisible_life_feb5451063
+                        mime: image/jpeg
+                        name: small_F_2_invisible_life.jpg
+                        size: 28.41
+                        width: 500
+                        height: 281
+                    medium:
+                        ext: .jpg
+                        url: /uploads/medium_F_2_invisible_life_feb5451063.jpg
+                        hash: medium_F_2_invisible_life_feb5451063
+                        mime: image/jpeg
+                        name: medium_F_2_invisible_life.jpg
+                        size: 53.8
+                        width: 750
+                        height: 422
+                    thumbnail:
+                        ext: .jpg
+                        url: /uploads/thumbnail_F_2_invisible_life_feb5451063.jpg
+                        hash: thumbnail_F_2_invisible_life_feb5451063
+                        mime: image/jpeg
+                        name: thumbnail_F_2_invisible_life.jpg
+                        size: 9.4
+                        width: 245
+                        height: 138
+                hash: F_2_invisible_life_feb5451063
+                ext: .jpg
+                mime: image/jpeg
+                size: 195.11
+                url: /uploads/F_2_invisible_life_feb5451063.jpg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-08-13T19:16:16.310Z'
+                updated_at: '2020-08-13T19:16:16.552Z'
+        image_et:
+            -
+                id: 4
+                name: F_1_invisible_life.jpg
+                alternativeText: ''
+                caption: ''
+                width: 1920
+                height: 1080
+                formats:
+                    large:
+                        ext: .jpg
+                        url: /uploads/large_F_1_invisible_life_745fc8df60.jpg
+                        hash: large_F_1_invisible_life_745fc8df60
+                        mime: image/jpeg
+                        name: large_F_1_invisible_life.jpg
+                        size: 81.71
+                        width: 1000
+                        height: 563
+                    small:
+                        ext: .jpg
+                        url: /uploads/small_F_1_invisible_life_745fc8df60.jpg
+                        hash: small_F_1_invisible_life_745fc8df60
+                        mime: image/jpeg
+                        name: small_F_1_invisible_life.jpg
+                        size: 24.04
+                        width: 500
+                        height: 281
+                    medium:
+                        ext: .jpg
+                        url: /uploads/medium_F_1_invisible_life_745fc8df60.jpg
+                        hash: medium_F_1_invisible_life_745fc8df60
+                        mime: image/jpeg
+                        name: medium_F_1_invisible_life.jpg
+                        size: 46.72
+                        width: 750
+                        height: 422
+                    thumbnail:
+                        ext: .jpg
+                        url: /uploads/thumbnail_F_1_invisible_life_745fc8df60.jpg
+                        hash: thumbnail_F_1_invisible_life_745fc8df60
+                        mime: image/jpeg
+                        name: thumbnail_F_1_invisible_life.jpg
+                        size: 8.1
+                        width: 245
+                        height: 138
+                hash: F_1_invisible_life_745fc8df60
+                ext: .jpg
+                mime: image/jpeg
+                size: 194.74
+                url: /uploads/F_1_invisible_life_745fc8df60.jpg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-08-13T19:16:16.414Z'
+                updated_at: '2020-08-13T19:16:16.648Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    title: test 4 en
+    slug: test-4-en
+    lead: lead 4 en
+    contents: cont 4 en
+    publish: true
+    directory: source/_fetchdir/articles_poff/test-4-en
+    path: article/test-4-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 9
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 3
+        firstname: Liis
+        lastname: Käsper
+    created_at: '2020-09-02T07:05:15.585Z'
+    updated_at: '2020-09-03T13:08:15.555Z'
+    title_et: Kumu dokumentaalfilmide sari alustab hooaega Tokaj veiniga
+    slug_et: kumu-dokumentaalfilmide-sari-alustab-hooaega-tokaj-veiniga
+    lead_et: >-
+        Kumu kultuuriteemaliste dokumentaalfilmide sügishooaja juhatab sisse
+        kuulsast Tokaj veinist rääkiv linateos.
+    contents_et: >-
+        Ungarlase Tamás Almási „Vedel kuld” (Folyékony arany) on esimene film
+        Ungari veinist, täpsemalt maailmakuulsast Aszú veinist, mille
+        valmistamise sajanditepikkuseid traditsioone kiiresti muutuv maailm üha
+        enam mõjutab.
+
+
+        26. augustil kell 18 Kumu auditooriumis linastuvat filmi juhatab sisse
+        Katrin Nabel Ungari Instituudist. 
+
+
+        Sari jätkub Damian Pettigrew´ klassikalise, 18 aastat tagasi valminud
+        filmiga „Fellini: ma olen sündinud valetaja” (Fellini: Sono un gran
+        bugiardo), mis on pühendatud maailmakuulsa filmirežissööri 100.
+        sünniaastapäevale, sisaldades ka tema viimaseid pihtimusi.
+
+
+        Kirjanik Tove Jansson ja kunstnik Tuulikki Pietilä veetsid 25 aastat oma
+        suvesid Soome lahes asuval tillukesel Klovharu saarel, kaasas
+        filmikaamera. Soome režissöörid Kanerva Cederström ja Riikka Tanner on
+        toona filmitust kokku pannud poeetilise linateose „Haru, üksildaste
+        saar”.
+
+
+        Rootsi dokumentalist Fredrik Gertten jälgib filmis „Push. Välja
+        tõrjutud” (Push), kuidas suurtes linnades viimastel aastatel taevasse
+        kerkinud korterihinnad sunnivad oma kodudest lahkuma põliseid elanikke.
+
+
+        Austerlaste Florian Weigensameri ja Christian Krönesi „Tere tulemast
+        Soodomasse!” (Welcome to Sodom) viib Ghana pealinnas Accras asuvale
+        maailma suurimale elektroonikaromude prügimäele, kus lõpetab enamasti
+        illegaalselt oma eksistentsi Esimese Maailma sodi. 6000 inimest, kes
+        seal elavad ja töötavad, nimetavad seda elavaks põrguks.
+
+
+        Stanley Nelsoni „Miles Davis: Birth of the Cool” portreteerib üht
+        maailma legendaarsemat džässmuusikut ja Sydney Pollacki „Amazing Grace”
+        jäädvustab Aretha Franklini 1972. aasta kontserdi, mille salvestusest
+        sai üks kõige aegade olulisemaid gospelmuusika plaate.
+
+
+        Briti nimekas režissöör Julien Temple lööb filmis „Habaneros” kuumade
+        kuuba rütmide saatel särama Havanna – haavatud, ent alistamatu linna,
+        mis köidab oma ilu, ajaloo ja elanike lõputu energiaga.
+
+
+        50 aastat tagasi lahkus meie seast rahvusvaheliselt tuntumaid eesti
+        kunstnikke Ülo Sooster. Lilija Vjugina „Ülo Sooster. Mees, kes kuivatas
+        rätikut tuule käes” on esimene nõnda põhjalik ülevaade sellest
+        modernismi suurkujust ja tema pärandist – omamoodi rännak ajas ja
+        ruumis, mille võtab ette kunstniku poeg Tenno.
+
+
+        Eelmise aasta olulisemaid Eesti dokumentaalfilme, Ksenija Ohhapkina
+        „Surematu” vaatleb elu Vene tööstuslinnas, näidates, kuidas ühiskond
+        vormib inimesest riiklikku ressurssi.
+
+
+        Prantsuse režissööri Frédéric Wilneri „Tutanhamoni hauakamber. Tegelik
+        lugu” (The True Story of King Tut’s Treasure) annab ülevaate
+        Vana-Egiptuse superstaari kuningas Tutanhamoni aarete viimastest
+        uuringutest, mille valguses tuleb seni teadaolev üle vaadata.
+
+
+        Hooaeg lõpeb 11. novembril, kui linastub Itaalia režissööri Anna de
+        Manincori „Peaaegu mittemidagi. Eksperimentaallinn CERN” (Almost Nothing
+        – CERN Experimental City), mis jälgib maailma suurima osakestefüüsika
+        labori ehk Euroopa tuumauuringute keskuse ulmelist igapäevaelu.
+
+
+        Kokku jõuab augustis, septembris, oktoobris ja novembris ekraanile 12
+        dokumentaalfilmi. Kõik seansid algavad Kumu auditooriumis kolmapäeviti
+        kell 18 ja on vaatajatele tasuta. Seanssidele eelnevad ekspertide
+        sissejuhatused.
+
+
+        Kultuuriteemaliste filmide sarja „Kumu dokumentaal” korraldavad Kumu ja
+        PÖFF.
+    publishFrom: '2020-08-24T09:00:00.000Z'
+    publish_et: true
+    publish_ru: true
+    media:
+        id: 16
+        imageDefault:
+            -
+                id: 28
+                name: Vedel-Kuld-e1598259521403-8ccd1c78.jpeg
+                alternativeText: ''
+                caption: ''
+                width: 1067
+                height: 600
+                formats:
+                    thumbnail:
+                        ext: .jpeg
+                        url: >-
+                            /uploads/thumbnail_Vedel_Kuld_e1598259521403_8ccd1c78_d3946bc2e5.jpeg
+                        hash: >-
+                            thumbnail_Vedel_Kuld_e1598259521403_8ccd1c78_d3946bc2e5
+                        mime: image/jpeg
+                        name: thumbnail_Vedel-Kuld-e1598259521403-8ccd1c78.jpeg
+                        size: 5.25
+                        width: 245
+                        height: 138
+                hash: Vedel_Kuld_e1598259521403_8ccd1c78_d3946bc2e5
+                ext: .jpeg
+                mime: image/jpeg
+                size: 38.72
+                url: /uploads/Vedel_Kuld_e1598259521403_8ccd1c78_d3946bc2e5.jpeg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-09-01T08:26:38.966Z'
+                updated_at: '2020-09-01T08:26:39.046Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    title: test 9 en
+    slug: test-9-en
+    lead: test 9 en lead
+    contents: test 9 en cont
+    publish: true
+    directory: source/_fetchdir/articles_poff/test-9-en
+    path: article/test-9-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 1
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 6
+        firstname: Jaan
+        lastname: Leppik
+    created_at: '2020-09-02T06:20:22.339Z'
+    updated_at: '2020-09-02T08:12:28.165Z'
+    title_et: Tartu armastusfilmide festival laieneb üle kogu Eesti
+    slug_et: tartu-armastusfilmide-festival-laieneb-uele-kogu-eesti
+    lead_et: >-
+        Juba 15. korda muutub Tartu Raekoja plats Eesti suurimaks vabaõhukinoks,
+        kui augusti teisel nädalal jõuab sealsele väliekraanile 11 armastusest
+        kõnelevat filmi.
+    contents_et: >-
+        Peale selle avab PÖFFi armastusfilmide festival Tartuff esimest korda ka
+        virtuaalse kinosaali, mida saab külastada üle kogu Eesti.
+
+
+        Filmid jõuavad publikuni telekommunikatsiooniettevõtte Elisa
+        veebiplatvormi Elisa Stage vahendusel, mis kandis üle ka Haapsalu õudus-
+        ja fantaasiafilmide festivali.
+
+
+        Traditsiooniliselt saab kõiki Tartus ekraanile jõudvaid filme vaadata
+        tasuta, virtuaalsetele seanssidele tuleb osta pilet.
+
+
+        „Virtuaalne festival on mõeldud neile, kes platsile ei mahu või ei saa
+        selleks ajaks Tartusse tulla. See annab võimaluse teha Tartuffi
+        programmiga tutvust ka neil, kes pole siia kunagi sattunud,” ütles
+        Tartuffi juht Kristiina Reidolv.
+
+
+        Koroonaviirusega seotud piirangute tõttu tuleb Raekoja platsile tuhat
+        istekohta, tagatakse 2+2 reegli järgimine ja desinfitseerimisvahendite
+        olemaolu. Athena keskuses linastuvate dokumentaal- ja lastefilmide puhul
+        rakendatakse 50-protsendilist saalitäitumuse reeglit.
+
+
+        10.–15. augustini toimuva armastusfilmide festivali alateemaks on tänavu
+        kujutav kunst. Programmi kuulub ligemale 20 filmi, lisaks arvukalt
+        eriüritusi, kuhu on kaasatud ka Tartu kunstimuuseum ja kõrgem kunstikool
+        Pallas.
+
+
+        Programmi avalikustab Tartuff juulis.
+
+
+        Eelmisel aastal kogus festival 15 000 külastust. Populaarseimad
+        linateosed olid Soome noortefilm „Rumal noor süda” ja Itaalia komöödia
+        “Kui ema on ära”, millest kumbki tõi raeplatsile 2300 vaatajat.
+
+
+        Tartuffi korraldab Pimedate Ööde filmifestival koostöös Tartu linna,
+        Tartu filmifondi ja Tartu loomemajanduskeskusega.
+    publishFrom: '2020-06-18T09:00:00.000Z'
+    publishUntil: '2021-01-14T10:00:00.000Z'
+    publish_et: true
+    publish_ru: true
+    media:
+        id: 8
+        imageDefault:
+            -
+                id: 5
+                name: tartuff_2019_ohust_1.jpg
+                alternativeText: ''
+                caption: ''
+                width: 1920
+                height: 1080
+                formats:
+                    large:
+                        ext: .jpg
+                        url: /uploads/large_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: large_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: large_tartuff_2019_ohust_1.jpg
+                        size: 120.83
+                        width: 1000
+                        height: 563
+                    small:
+                        ext: .jpg
+                        url: /uploads/small_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: small_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: small_tartuff_2019_ohust_1.jpg
+                        size: 32.61
+                        width: 500
+                        height: 281
+                    medium:
+                        ext: .jpg
+                        url: /uploads/medium_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: medium_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: medium_tartuff_2019_ohust_1.jpg
+                        size: 68.02
+                        width: 750
+                        height: 422
+                    thumbnail:
+                        ext: .jpg
+                        url: >-
+                            /uploads/thumbnail_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: thumbnail_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: thumbnail_tartuff_2019_ohust_1.jpg
+                        size: 8.98
+                        width: 245
+                        height: 138
+                hash: tartuff_2019_ohust_1_778c8d54c2
+                ext: .jpg
+                mime: image/jpeg
+                size: 323.02
+                url: /uploads/tartuff_2019_ohust_1_778c8d54c2.jpg
+                provider: local
+                created_by: 3
+                updated_by: 3
+                created_at: '2020-08-26T13:51:45.254Z'
+                updated_at: '2020-08-26T13:51:45.327Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    tag_premiere_types:
+        - International Premiere
+    tag_programmes:
+        - Official Selection
+    tag_genres:
+        - Drama
+    tag_keywords:
+        - MeToo
+        - Society
+    title: Test EN
+    slug: test-en
+    lead: Lead EN
+    contents: Cont EN
+    publish: true
+    directory: source/_fetchdir/articles_poff/test-en
+    path: article/test-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 8
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    created_at: '2020-09-02T07:04:20.609Z'
+    updated_at: '2020-09-02T11:47:03.136Z'
+    title_et: Tartuffi publikuauhind rändab Itaaliasse
+    slug_et: test-8-et
+    lead_et: >-
+        PÖFFi armastusfilmide festivali Tartuff publik valis oma lemmikuks
+        Itaalia draamakomöödia „Õnnejumalanna”.
+    contents_et: >-
+        Ferzan Özpeteki filmis peavad kaks lastekauget, oma suhtega kriisi
+        jõudnud meest kantseldama lapsi, kes neile hoida jäetakse.
+
+
+        Filmi režissöör saab auhinnaks Mati Karmini skulptuuri „Suudlevad
+        tudengid”.
+
+
+        Ööl vastu pühapäeva lõppenud festivali populaarseim film oli Soome
+        draama „Harjumuse jõud”, mida vaatas Raekoja platsi vabaõhukinos 700
+        inimest. Festivali virtuaalses kinos Elisa Stage kogus enim vaatamisi –
+        ligemale 300 – Norra dokumentaalfilm „Autoportree”.
+
+
+        Koos üritustega sai Tartus festivalist osa ligemale 6300 inimest,
+        virtuaalset kino külastati üle Eesti 1200 korda.
+
+
+        „Me oleme väga tänulikud publikule, kes käitus äreval ajal
+        vastutustundlikult ja täitis kõiki reegleid,” ütles festivali juht
+        Kristiina Reidolv Tartu hiljutisele koroonapuhangule viidates. Samuti
+        tõstis ta esile Tartu kunstiorganisatsioonide koostööd, mille tulemusena
+        toimus ligemale 30 üritust.
+
+
+        15. PÖFFi armastusfilmide festival Tartuff leidis aset 10.–15.
+        augustini. Festivali fookuses oli kunst. Koroonaviiruse tõttu toimus
+        festival piiratud publikuhulgaga, samuti rakendati teisi
+        ettevaatusabinõusid. Esimest korda sai kümmet filmi vaadata virtuaalselt
+        üle kogu Eesti. Festivali filme saab näha veel 19.–22. augustini
+        Tallinnas Filmimuuseumis.
+
+
+        Tartuffi korraldab Pimedate Ööde filmifestival koostöös Tartu linna,
+        Tartu filmifondi ja Tartu loomemajanduskeskusega.
+    publishFrom: '2020-05-18T09:00:00.000Z'
+    publishUntil: '2020-11-10T10:00:00.000Z'
+    publish_et: false
+    publish_ru: true
+    media:
+        id: 15
+        imageDefault:
+            -
+                id: 5
+                name: tartuff_2019_ohust_1.jpg
+                alternativeText: ''
+                caption: ''
+                width: 1920
+                height: 1080
+                formats:
+                    large:
+                        ext: .jpg
+                        url: /uploads/large_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: large_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: large_tartuff_2019_ohust_1.jpg
+                        size: 120.83
+                        width: 1000
+                        height: 563
+                    small:
+                        ext: .jpg
+                        url: /uploads/small_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: small_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: small_tartuff_2019_ohust_1.jpg
+                        size: 32.61
+                        width: 500
+                        height: 281
+                    medium:
+                        ext: .jpg
+                        url: /uploads/medium_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: medium_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: medium_tartuff_2019_ohust_1.jpg
+                        size: 68.02
+                        width: 750
+                        height: 422
+                    thumbnail:
+                        ext: .jpg
+                        url: >-
+                            /uploads/thumbnail_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: thumbnail_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: thumbnail_tartuff_2019_ohust_1.jpg
+                        size: 8.98
+                        width: 245
+                        height: 138
+                hash: tartuff_2019_ohust_1_778c8d54c2
+                ext: .jpg
+                mime: image/jpeg
+                size: 323.02
+                url: /uploads/tartuff_2019_ohust_1_778c8d54c2.jpg
+                provider: local
+                created_by: 3
+                updated_by: 3
+                created_at: '2020-08-26T13:51:45.254Z'
+                updated_at: '2020-08-26T13:51:45.327Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    tag_premiere_types:
+        - European premiere
+    tag_programmes:
+        - Official Selection
+    tag_genres:
+        - Drama
+        - Animation
+    tag_keywords:
+        - Society
+    web_authors:
+        -
+            id: 1
+            namePrivate: Pöffihunt
+            created_by: 6
+            updated_by: 6
+            created_at: '2020-09-02T11:27:48.489Z'
+            updated_at: '2020-09-02T11:27:48.544Z'
+            name: Wolf
+        -
+            id: 2
+            namePrivate: Toimetaja
+            created_by: 6
+            updated_by: 6
+            created_at: '2020-09-02T11:28:23.386Z'
+            updated_at: '2020-09-02T11:28:23.428Z'
+            name: Editor
+    title: test 8 en
+    slug: test-8-en
+    lead: test 8 en lead
+    contents: test 8 en cont
+    publish: true
+    directory: source/_fetchdir/articles_poff/test-8-en
+    path: article/test-8-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 11
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    created_at: '2020-09-03T15:18:01.174Z'
+    updated_at: '2020-09-03T15:18:29.859Z'
+    title_et: TEST ARTIKKEL 2
+    slug_et: test-artikkel-2
+    title_ru: TEST ARTIKKEL 2
+    slug_ru: test-artikkel-2
+    lead_et: TEST ARTIKKEL 2
+    lead_ru: TEST ARTIKKEL 2
+    contents_et: TEST ARTIKKEL 2
+    contents_ru: TEST ARTIKKEL 2
+    publishFrom: '2020-09-01T09:00:00.000Z'
+    publish_et: true
+    article_types: []
+    title: TEST ARTIKKEL 2
+    slug: test-artikkel-2
+    lead: TEST ARTIKKEL 2
+    contents: TEST ARTIKKEL 2
+    directory: source/_fetchdir/articles_poff/test-artikkel-2
+    path: article/test-artikkel-2
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 12
+    created_by:
+        id: 3
+        firstname: Liis
+        lastname: Käsper
+    updated_by:
+        id: 3
+        firstname: Liis
+        lastname: Käsper
+    created_at: '2020-09-04T06:41:03.958Z'
+    updated_at: '2020-09-04T08:24:36.805Z'
+    title_et: TEST33
+    slug_et: pof-fi-article
+    slug_ru: pof-fi-article
+    publishFrom: '2020-09-16T09:00:00.000Z'
+    publish_et: true
+    article_types: []
+    slug: pof-fi-article
+    directory: source/_fetchdir/articles_poff/pof-fi-article
+    path: article/pof-fi-article
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.en.yaml
+-
+    id: 5
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 6
+        firstname: Jaan
+        lastname: Leppik
+    created_at: '2020-09-02T07:00:57.082Z'
+    updated_at: '2020-09-02T08:01:22.167Z'
     title_en: test 5 en
     slug_en: test-5-en
     lead_en: Lead 5 en

--- a/source/articles.ru.yaml
+++ b/source/articles.ru.yaml
@@ -1,170 +1,4 @@
 -
-    id: 5
-    created_by:
-        id: 5
-        firstname: Martin
-        lastname: Pennaste
-    updated_by:
-        id: 6
-        firstname: Jaan
-        lastname: Leppik
-    created_at: '2020-09-02T07:00:57.082Z'
-    updated_at: '2020-09-02T08:01:22.167Z'
-    title_et: Mitte ainult filmid! Tartuff pakub ka põnevaid üritusi
-    slug_et: mitte-ainult-filmid-tartuff-pakub-ka-ponevaid-ueritusi
-    title_en: test 5 en
-    slug_en: test-5-en
-    lead_et: >-
-        Mida põnevat võib leida Eesti tänavakunstipealinna Tartu seintelt? Kui
-        levinud on naiste ahistamine Soomes? Milline võiks välja näha
-        hommikupiknik Emajõe lodjal?
-    lead_en: Lead 5 en
-    contents_et: >-
-        Vastused leiate juba 10. augustil Tartus avataval PÖFFi armastusfilmide
-        festivalil Tartuff, mis toob lisaks filmidele huviliste ette rikkaliku
-        ürituste kava.
-
-
-        Mõned nopped:
-
-
-        - duo Maarja Nuut & Ruum annab vabaõhukontserdi, mis avab festivali;
-
-        - Joosep Matjus ja Jaan Tootsen viivad lodjapiknikule mööda Emajõge;
-
-        - kunstirühmituse Ajuokse asutaja Stina Leek korraldab
-        tänavakunstiaktsiooni;
-
-        - tänavakunstifestival Stencibility tutvustab jalgrattatuuridel uuemat
-        ja vanemat tänavakunsti;
-
-        - supilinlane Kadri Kosk avab oma värvilises majas aianäituse ja
-        kodukohviku;
-
-        - Voronja galerii sõidutab enda juurde, kus on avatud näitus „Kättemaks”
-        ja toimub Robert ja Anti Jürjendali kontsert;
-
-        - Loomingu Raamatukogu esitleb Milan Kundera raamatut „Veidrad
-        armastuslood”;
-
-        - Tartu Kunstimuuseum korraldab sümpoosioni „Fotograafia retušeerimata
-        ajalugu”;
-
-        - Eesti dokumentalistide gild tutvustab valmivaid kunstiteemalisi
-        dokumentaalfilme.
-
-        Kokku on üritusi ligemale 30 üle terve Tartu.
-
-
-        Suur osa neist leiab aset festivali klubis, mis kannab nime Pepe´s
-        Bistro & Tartuff Social Club ja asub aadressil Ülikooli 7. Näiteks saab
-        seal kuulata ansambleid Forrest Kämp ja Miré ning osaleda armastuse- ja
-        filmiteemalistel mälumängudel. Samas toimub ka kohtumine festivali
-        külalise, Soome näitleja Suvi Blickiga, kes mängib ahistamist käsitlevas
-        filmis „Harjumuse jõud”.
-
-
-        Festivaliklubi üritused on tasuta, nagu ka kõik Tartus toimuvad
-        filmiseansid.
-
-
-        Ürituste programm valmis koostöös Tartu kunstimuuseumi, Eesti Rahva
-        Muuseumi, Voronja galerii, Tartu Ülikooli semiootika osakonna, Eesti
-        dokumentalistide gildi, Emajõe lodjaseltsi, Loomingu Raamatukogu,
-        Genialistide klubi, Pepe´s Bistro & Social Clubi,
-        tänavakunstifestivaliga Stencibility, kõrgema kunstikooliga Pallas,
-        kirjastusega Loovhoog ning Maarja Nuudi ja Ruumiga.
-
-
-        PÖFFi armastusfilmide festival Tartuff toimub tänavu 10.-15. augustini
-        samaaegselt Tartus ja veebiplatvormil Elisa Stage ning selle alateemaks
-        on kunst.
-    contents_en: >-
-        cont 5  encont 5  encont 5  encont 5  encont 5  encont 5  encont 5 
-        encont 5  encont 5  encont 5  encont 5  encont 5  encont 5  encont 5 
-        encont 5  encont 5  encont 5  encont 5  encont 5  encont 5  en
-    publishFrom: '2020-08-07T09:00:00.000Z'
-    publishUntil: '2021-01-07T10:00:00.000Z'
-    publish_et: true
-    publish_en: true
-    media:
-        id: 12
-        imageDefault:
-            -
-                id: 32
-                name: F_1_maudie.jpg
-                alternativeText: ''
-                caption: ''
-                width: 1920
-                height: 1080
-                formats:
-                    thumbnail:
-                        ext: .jpg
-                        url: /uploads/thumbnail_F_1_maudie_8754a1bf4d.jpg
-                        hash: thumbnail_F_1_maudie_8754a1bf4d
-                        mime: image/jpeg
-                        name: thumbnail_F_1_maudie.jpg
-                        size: 8.44
-                        width: 245
-                        height: 138
-                hash: F_1_maudie_8754a1bf4d
-                ext: .jpg
-                mime: image/jpeg
-                size: 182.99
-                url: /uploads/F_1_maudie_8754a1bf4d.jpg
-                provider: local
-                created_by: 6
-                updated_by: 6
-                created_at: '2020-09-01T12:30:02.744Z'
-                updated_at: '2020-09-01T12:30:02.829Z'
-        image_et:
-            -
-                id: 33
-                name: maarjanuut-scaled-2020.jpeg
-                alternativeText: ''
-                caption: ''
-                width: 1067
-                height: 600
-                formats:
-                    thumbnail:
-                        ext: .jpeg
-                        url: >-
-                            /uploads/thumbnail_maarjanuut_scaled_2020_63516cc8aa.jpeg
-                        hash: thumbnail_maarjanuut_scaled_2020_63516cc8aa
-                        mime: image/jpeg
-                        name: thumbnail_maarjanuut-scaled-2020.jpeg
-                        size: 7.51
-                        width: 245
-                        height: 138
-                hash: maarjanuut_scaled_2020_63516cc8aa
-                ext: .jpeg
-                mime: image/jpeg
-                size: 75.64
-                url: /uploads/maarjanuut_scaled_2020_63516cc8aa.jpeg
-                provider: local
-                created_by: 6
-                updated_by: 6
-                created_at: '2020-09-01T12:44:38.655Z'
-                updated_at: '2020-09-01T12:44:38.738Z'
-        image: []
-    article_types:
-        -
-            id: 2
-            name: Uudis
-            created_by: 6
-            updated_by: 1
-            created_at: '2020-08-18T13:49:51.616Z'
-            updated_at: '2020-08-27T13:27:26.065Z'
-            article: null
-            et: Uudised
-            en: News
-            ru: Новости
-    publish: true
-    directory: source/_fetchdir/articles_poff/test-5-en
-    data:
-        pictures: /article_pictures.yaml
-        screenings: /film/screenings.ru.yaml
--
     id: 7
     created_by:
         id: 5
@@ -557,6 +391,172 @@
             ru: Новости
     publish: true
     directory: source/_fetchdir/articles_poff/test-3-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.ru.yaml
+-
+    id: 5
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 6
+        firstname: Jaan
+        lastname: Leppik
+    created_at: '2020-09-02T07:00:57.082Z'
+    updated_at: '2020-09-02T08:01:22.167Z'
+    title_et: Mitte ainult filmid! Tartuff pakub ka põnevaid üritusi
+    slug_et: mitte-ainult-filmid-tartuff-pakub-ka-ponevaid-ueritusi
+    title_en: test 5 en
+    slug_en: test-5-en
+    lead_et: >-
+        Mida põnevat võib leida Eesti tänavakunstipealinna Tartu seintelt? Kui
+        levinud on naiste ahistamine Soomes? Milline võiks välja näha
+        hommikupiknik Emajõe lodjal?
+    lead_en: Lead 5 en
+    contents_et: >-
+        Vastused leiate juba 10. augustil Tartus avataval PÖFFi armastusfilmide
+        festivalil Tartuff, mis toob lisaks filmidele huviliste ette rikkaliku
+        ürituste kava.
+
+
+        Mõned nopped:
+
+
+        - duo Maarja Nuut & Ruum annab vabaõhukontserdi, mis avab festivali;
+
+        - Joosep Matjus ja Jaan Tootsen viivad lodjapiknikule mööda Emajõge;
+
+        - kunstirühmituse Ajuokse asutaja Stina Leek korraldab
+        tänavakunstiaktsiooni;
+
+        - tänavakunstifestival Stencibility tutvustab jalgrattatuuridel uuemat
+        ja vanemat tänavakunsti;
+
+        - supilinlane Kadri Kosk avab oma värvilises majas aianäituse ja
+        kodukohviku;
+
+        - Voronja galerii sõidutab enda juurde, kus on avatud näitus „Kättemaks”
+        ja toimub Robert ja Anti Jürjendali kontsert;
+
+        - Loomingu Raamatukogu esitleb Milan Kundera raamatut „Veidrad
+        armastuslood”;
+
+        - Tartu Kunstimuuseum korraldab sümpoosioni „Fotograafia retušeerimata
+        ajalugu”;
+
+        - Eesti dokumentalistide gild tutvustab valmivaid kunstiteemalisi
+        dokumentaalfilme.
+
+        Kokku on üritusi ligemale 30 üle terve Tartu.
+
+
+        Suur osa neist leiab aset festivali klubis, mis kannab nime Pepe´s
+        Bistro & Tartuff Social Club ja asub aadressil Ülikooli 7. Näiteks saab
+        seal kuulata ansambleid Forrest Kämp ja Miré ning osaleda armastuse- ja
+        filmiteemalistel mälumängudel. Samas toimub ka kohtumine festivali
+        külalise, Soome näitleja Suvi Blickiga, kes mängib ahistamist käsitlevas
+        filmis „Harjumuse jõud”.
+
+
+        Festivaliklubi üritused on tasuta, nagu ka kõik Tartus toimuvad
+        filmiseansid.
+
+
+        Ürituste programm valmis koostöös Tartu kunstimuuseumi, Eesti Rahva
+        Muuseumi, Voronja galerii, Tartu Ülikooli semiootika osakonna, Eesti
+        dokumentalistide gildi, Emajõe lodjaseltsi, Loomingu Raamatukogu,
+        Genialistide klubi, Pepe´s Bistro & Social Clubi,
+        tänavakunstifestivaliga Stencibility, kõrgema kunstikooliga Pallas,
+        kirjastusega Loovhoog ning Maarja Nuudi ja Ruumiga.
+
+
+        PÖFFi armastusfilmide festival Tartuff toimub tänavu 10.-15. augustini
+        samaaegselt Tartus ja veebiplatvormil Elisa Stage ning selle alateemaks
+        on kunst.
+    contents_en: >-
+        cont 5  encont 5  encont 5  encont 5  encont 5  encont 5  encont 5 
+        encont 5  encont 5  encont 5  encont 5  encont 5  encont 5  encont 5 
+        encont 5  encont 5  encont 5  encont 5  encont 5  encont 5  en
+    publishFrom: '2020-08-07T09:00:00.000Z'
+    publishUntil: '2021-01-07T10:00:00.000Z'
+    publish_et: true
+    publish_en: true
+    media:
+        id: 12
+        imageDefault:
+            -
+                id: 32
+                name: F_1_maudie.jpg
+                alternativeText: ''
+                caption: ''
+                width: 1920
+                height: 1080
+                formats:
+                    thumbnail:
+                        ext: .jpg
+                        url: /uploads/thumbnail_F_1_maudie_8754a1bf4d.jpg
+                        hash: thumbnail_F_1_maudie_8754a1bf4d
+                        mime: image/jpeg
+                        name: thumbnail_F_1_maudie.jpg
+                        size: 8.44
+                        width: 245
+                        height: 138
+                hash: F_1_maudie_8754a1bf4d
+                ext: .jpg
+                mime: image/jpeg
+                size: 182.99
+                url: /uploads/F_1_maudie_8754a1bf4d.jpg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-09-01T12:30:02.744Z'
+                updated_at: '2020-09-01T12:30:02.829Z'
+        image_et:
+            -
+                id: 33
+                name: maarjanuut-scaled-2020.jpeg
+                alternativeText: ''
+                caption: ''
+                width: 1067
+                height: 600
+                formats:
+                    thumbnail:
+                        ext: .jpeg
+                        url: >-
+                            /uploads/thumbnail_maarjanuut_scaled_2020_63516cc8aa.jpeg
+                        hash: thumbnail_maarjanuut_scaled_2020_63516cc8aa
+                        mime: image/jpeg
+                        name: thumbnail_maarjanuut-scaled-2020.jpeg
+                        size: 7.51
+                        width: 245
+                        height: 138
+                hash: maarjanuut_scaled_2020_63516cc8aa
+                ext: .jpeg
+                mime: image/jpeg
+                size: 75.64
+                url: /uploads/maarjanuut_scaled_2020_63516cc8aa.jpeg
+                provider: local
+                created_by: 6
+                updated_by: 6
+                created_at: '2020-09-01T12:44:38.655Z'
+                updated_at: '2020-09-01T12:44:38.738Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    publish: true
+    directory: source/_fetchdir/articles_poff/test-5-en
     data:
         pictures: /article_pictures.yaml
         screenings: /film/screenings.ru.yaml
@@ -1077,159 +1077,6 @@
         pictures: /article_pictures.yaml
         screenings: /film/screenings.ru.yaml
 -
-    id: 1
-    created_by:
-        id: 5
-        firstname: Martin
-        lastname: Pennaste
-    updated_by:
-        id: 6
-        firstname: Jaan
-        lastname: Leppik
-    created_at: '2020-09-02T06:20:22.339Z'
-    updated_at: '2020-09-02T08:12:28.165Z'
-    title_et: Tartu armastusfilmide festival laieneb üle kogu Eesti
-    slug_et: tartu-armastusfilmide-festival-laieneb-uele-kogu-eesti
-    title_en: Test EN
-    slug_en: test-en
-    lead_et: >-
-        Juba 15. korda muutub Tartu Raekoja plats Eesti suurimaks vabaõhukinoks,
-        kui augusti teisel nädalal jõuab sealsele väliekraanile 11 armastusest
-        kõnelevat filmi.
-    lead_en: Lead EN
-    contents_et: >-
-        Peale selle avab PÖFFi armastusfilmide festival Tartuff esimest korda ka
-        virtuaalse kinosaali, mida saab külastada üle kogu Eesti.
-
-
-        Filmid jõuavad publikuni telekommunikatsiooniettevõtte Elisa
-        veebiplatvormi Elisa Stage vahendusel, mis kandis üle ka Haapsalu õudus-
-        ja fantaasiafilmide festivali.
-
-
-        Traditsiooniliselt saab kõiki Tartus ekraanile jõudvaid filme vaadata
-        tasuta, virtuaalsetele seanssidele tuleb osta pilet.
-
-
-        „Virtuaalne festival on mõeldud neile, kes platsile ei mahu või ei saa
-        selleks ajaks Tartusse tulla. See annab võimaluse teha Tartuffi
-        programmiga tutvust ka neil, kes pole siia kunagi sattunud,” ütles
-        Tartuffi juht Kristiina Reidolv.
-
-
-        Koroonaviirusega seotud piirangute tõttu tuleb Raekoja platsile tuhat
-        istekohta, tagatakse 2+2 reegli järgimine ja desinfitseerimisvahendite
-        olemaolu. Athena keskuses linastuvate dokumentaal- ja lastefilmide puhul
-        rakendatakse 50-protsendilist saalitäitumuse reeglit.
-
-
-        10.–15. augustini toimuva armastusfilmide festivali alateemaks on tänavu
-        kujutav kunst. Programmi kuulub ligemale 20 filmi, lisaks arvukalt
-        eriüritusi, kuhu on kaasatud ka Tartu kunstimuuseum ja kõrgem kunstikool
-        Pallas.
-
-
-        Programmi avalikustab Tartuff juulis.
-
-
-        Eelmisel aastal kogus festival 15 000 külastust. Populaarseimad
-        linateosed olid Soome noortefilm „Rumal noor süda” ja Itaalia komöödia
-        “Kui ema on ära”, millest kumbki tõi raeplatsile 2300 vaatajat.
-
-
-        Tartuffi korraldab Pimedate Ööde filmifestival koostöös Tartu linna,
-        Tartu filmifondi ja Tartu loomemajanduskeskusega.
-    contents_en: Cont EN
-    publishFrom: '2020-06-18T09:00:00.000Z'
-    publishUntil: '2021-01-14T10:00:00.000Z'
-    publish_et: true
-    publish_en: true
-    media:
-        id: 8
-        imageDefault:
-            -
-                id: 5
-                name: tartuff_2019_ohust_1.jpg
-                alternativeText: ''
-                caption: ''
-                width: 1920
-                height: 1080
-                formats:
-                    large:
-                        ext: .jpg
-                        url: /uploads/large_tartuff_2019_ohust_1_778c8d54c2.jpg
-                        hash: large_tartuff_2019_ohust_1_778c8d54c2
-                        mime: image/jpeg
-                        name: large_tartuff_2019_ohust_1.jpg
-                        size: 120.83
-                        width: 1000
-                        height: 563
-                    small:
-                        ext: .jpg
-                        url: /uploads/small_tartuff_2019_ohust_1_778c8d54c2.jpg
-                        hash: small_tartuff_2019_ohust_1_778c8d54c2
-                        mime: image/jpeg
-                        name: small_tartuff_2019_ohust_1.jpg
-                        size: 32.61
-                        width: 500
-                        height: 281
-                    medium:
-                        ext: .jpg
-                        url: /uploads/medium_tartuff_2019_ohust_1_778c8d54c2.jpg
-                        hash: medium_tartuff_2019_ohust_1_778c8d54c2
-                        mime: image/jpeg
-                        name: medium_tartuff_2019_ohust_1.jpg
-                        size: 68.02
-                        width: 750
-                        height: 422
-                    thumbnail:
-                        ext: .jpg
-                        url: >-
-                            /uploads/thumbnail_tartuff_2019_ohust_1_778c8d54c2.jpg
-                        hash: thumbnail_tartuff_2019_ohust_1_778c8d54c2
-                        mime: image/jpeg
-                        name: thumbnail_tartuff_2019_ohust_1.jpg
-                        size: 8.98
-                        width: 245
-                        height: 138
-                hash: tartuff_2019_ohust_1_778c8d54c2
-                ext: .jpg
-                mime: image/jpeg
-                size: 323.02
-                url: /uploads/tartuff_2019_ohust_1_778c8d54c2.jpg
-                provider: local
-                created_by: 3
-                updated_by: 3
-                created_at: '2020-08-26T13:51:45.254Z'
-                updated_at: '2020-08-26T13:51:45.327Z'
-        image: []
-    article_types:
-        -
-            id: 2
-            name: Uudis
-            created_by: 6
-            updated_by: 1
-            created_at: '2020-08-18T13:49:51.616Z'
-            updated_at: '2020-08-27T13:27:26.065Z'
-            article: null
-            et: Uudised
-            en: News
-            ru: Новости
-    tag_premiere_types:
-        - Международная премьера
-    tag_programmes:
-        - Основная конкурсная программа
-    tag_genres:
-        - Драма
-    tag_keywords:
-        - MeToo
-        - Общество
-    publish: true
-    directory: source/_fetchdir/articles_poff/test-en
-    data:
-        pictures: /article_pictures.yaml
-        screenings: /film/screenings.ru.yaml
--
     id: 8
     created_by:
         id: 5
@@ -1393,6 +1240,183 @@
         pictures: /article_pictures.yaml
         screenings: /film/screenings.ru.yaml
 -
+    id: 1
+    created_by:
+        id: 5
+        firstname: Martin
+        lastname: Pennaste
+    updated_by:
+        id: 6
+        firstname: Jaan
+        lastname: Leppik
+    created_at: '2020-09-02T06:20:22.339Z'
+    updated_at: '2020-09-02T08:12:28.165Z'
+    title_et: Tartu armastusfilmide festival laieneb üle kogu Eesti
+    slug_et: tartu-armastusfilmide-festival-laieneb-uele-kogu-eesti
+    title_en: Test EN
+    slug_en: test-en
+    lead_et: >-
+        Juba 15. korda muutub Tartu Raekoja plats Eesti suurimaks vabaõhukinoks,
+        kui augusti teisel nädalal jõuab sealsele väliekraanile 11 armastusest
+        kõnelevat filmi.
+    lead_en: Lead EN
+    contents_et: >-
+        Peale selle avab PÖFFi armastusfilmide festival Tartuff esimest korda ka
+        virtuaalse kinosaali, mida saab külastada üle kogu Eesti.
+
+
+        Filmid jõuavad publikuni telekommunikatsiooniettevõtte Elisa
+        veebiplatvormi Elisa Stage vahendusel, mis kandis üle ka Haapsalu õudus-
+        ja fantaasiafilmide festivali.
+
+
+        Traditsiooniliselt saab kõiki Tartus ekraanile jõudvaid filme vaadata
+        tasuta, virtuaalsetele seanssidele tuleb osta pilet.
+
+
+        „Virtuaalne festival on mõeldud neile, kes platsile ei mahu või ei saa
+        selleks ajaks Tartusse tulla. See annab võimaluse teha Tartuffi
+        programmiga tutvust ka neil, kes pole siia kunagi sattunud,” ütles
+        Tartuffi juht Kristiina Reidolv.
+
+
+        Koroonaviirusega seotud piirangute tõttu tuleb Raekoja platsile tuhat
+        istekohta, tagatakse 2+2 reegli järgimine ja desinfitseerimisvahendite
+        olemaolu. Athena keskuses linastuvate dokumentaal- ja lastefilmide puhul
+        rakendatakse 50-protsendilist saalitäitumuse reeglit.
+
+
+        10.–15. augustini toimuva armastusfilmide festivali alateemaks on tänavu
+        kujutav kunst. Programmi kuulub ligemale 20 filmi, lisaks arvukalt
+        eriüritusi, kuhu on kaasatud ka Tartu kunstimuuseum ja kõrgem kunstikool
+        Pallas.
+
+
+        Programmi avalikustab Tartuff juulis.
+
+
+        Eelmisel aastal kogus festival 15 000 külastust. Populaarseimad
+        linateosed olid Soome noortefilm „Rumal noor süda” ja Itaalia komöödia
+        “Kui ema on ära”, millest kumbki tõi raeplatsile 2300 vaatajat.
+
+
+        Tartuffi korraldab Pimedate Ööde filmifestival koostöös Tartu linna,
+        Tartu filmifondi ja Tartu loomemajanduskeskusega.
+    contents_en: Cont EN
+    publishFrom: '2020-06-18T09:00:00.000Z'
+    publishUntil: '2021-01-14T10:00:00.000Z'
+    publish_et: true
+    publish_en: true
+    media:
+        id: 8
+        imageDefault:
+            -
+                id: 5
+                name: tartuff_2019_ohust_1.jpg
+                alternativeText: ''
+                caption: ''
+                width: 1920
+                height: 1080
+                formats:
+                    large:
+                        ext: .jpg
+                        url: /uploads/large_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: large_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: large_tartuff_2019_ohust_1.jpg
+                        size: 120.83
+                        width: 1000
+                        height: 563
+                    small:
+                        ext: .jpg
+                        url: /uploads/small_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: small_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: small_tartuff_2019_ohust_1.jpg
+                        size: 32.61
+                        width: 500
+                        height: 281
+                    medium:
+                        ext: .jpg
+                        url: /uploads/medium_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: medium_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: medium_tartuff_2019_ohust_1.jpg
+                        size: 68.02
+                        width: 750
+                        height: 422
+                    thumbnail:
+                        ext: .jpg
+                        url: >-
+                            /uploads/thumbnail_tartuff_2019_ohust_1_778c8d54c2.jpg
+                        hash: thumbnail_tartuff_2019_ohust_1_778c8d54c2
+                        mime: image/jpeg
+                        name: thumbnail_tartuff_2019_ohust_1.jpg
+                        size: 8.98
+                        width: 245
+                        height: 138
+                hash: tartuff_2019_ohust_1_778c8d54c2
+                ext: .jpg
+                mime: image/jpeg
+                size: 323.02
+                url: /uploads/tartuff_2019_ohust_1_778c8d54c2.jpg
+                provider: local
+                created_by: 3
+                updated_by: 3
+                created_at: '2020-08-26T13:51:45.254Z'
+                updated_at: '2020-08-26T13:51:45.327Z'
+        image: []
+    article_types:
+        -
+            id: 2
+            name: Uudis
+            created_by: 6
+            updated_by: 1
+            created_at: '2020-08-18T13:49:51.616Z'
+            updated_at: '2020-08-27T13:27:26.065Z'
+            article: null
+            et: Uudised
+            en: News
+            ru: Новости
+    tag_premiere_types:
+        - Международная премьера
+    tag_programmes:
+        - Основная конкурсная программа
+    tag_genres:
+        - Драма
+    tag_keywords:
+        - MeToo
+        - Общество
+    publish: true
+    directory: source/_fetchdir/articles_poff/test-en
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.ru.yaml
+-
+    id: 12
+    created_by:
+        id: 3
+        firstname: Liis
+        lastname: Käsper
+    updated_by:
+        id: 3
+        firstname: Liis
+        lastname: Käsper
+    created_at: '2020-09-04T06:41:03.958Z'
+    updated_at: '2020-09-04T08:24:36.805Z'
+    title_et: TEST33
+    slug_et: pof-fi-article
+    slug_en: pof-fi-article
+    publishFrom: '2020-09-16T09:00:00.000Z'
+    publish_et: true
+    article_types: []
+    slug: pof-fi-article
+    directory: source/_fetchdir/articles_poff/pof-fi-article
+    path: article/pof-fi-article
+    data:
+        pictures: /article_pictures.yaml
+        screenings: /film/screenings.ru.yaml
+-
     id: 11
     created_by:
         id: 5
@@ -1421,30 +1445,6 @@
     contents: TEST ARTIKKEL 2
     directory: source/_fetchdir/articles_poff/test-artikkel-2
     path: article/test-artikkel-2
-    data:
-        pictures: /article_pictures.yaml
-        screenings: /film/screenings.ru.yaml
--
-    id: 12
-    created_by:
-        id: 3
-        firstname: Liis
-        lastname: Käsper
-    updated_by:
-        id: 3
-        firstname: Liis
-        lastname: Käsper
-    created_at: '2020-09-04T06:41:03.958Z'
-    updated_at: '2020-09-04T08:24:36.805Z'
-    title_et: TEST33
-    slug_et: pof-fi-article
-    slug_en: pof-fi-article
-    publishFrom: '2020-09-16T09:00:00.000Z'
-    publish_et: true
-    article_types: []
-    slug: pof-fi-article
-    directory: source/_fetchdir/articles_poff/pof-fi-article
-    path: article/pof-fi-article
     data:
         pictures: /article_pictures.yaml
         screenings: /film/screenings.ru.yaml

--- a/source/film/fetch_films_from_strapi.js
+++ b/source/film/fetch_films_from_strapi.js
@@ -10,8 +10,8 @@ let allData = []; // for films view
 function fetchAllData(options){
     // getData(new directory path, language, copy file, show error when slug_en missing, files to load data from, connectionOptions, CallBackFunction)
     getData("source/_fetchdir/films_poff/", "en", 1, 1, {'pictures': '/film_pictures.yaml', 'screenings': '/film/screenings.en.yaml'}, options, getDataCB);
-    getData("source/_fetchdir/films_poff//", "et", 0, 0, {'pictures': '/film_pictures.yaml', 'screenings': '/film/screenings.et.yaml'}, options, getDataCB);
-    getData("source/_fetchdir/films_poff//", "ru", 0, 0, {'pictures': '/film_pictures.yaml', 'screenings': '/film/screenings.ru.yaml'}, options, getDataCB);
+    getData("source/_fetchdir/films_poff/", "et", 0, 0, {'pictures': '/film_pictures.yaml', 'screenings': '/film/screenings.et.yaml'}, options, getDataCB);
+    getData("source/_fetchdir/films_poff/", "ru", 0, 0, {'pictures': '/film_pictures.yaml', 'screenings': '/film/screenings.ru.yaml'}, options, getDataCB);
 }
 
 function getToken() {
@@ -66,7 +66,14 @@ function fetchAll(token) {
 }
 
 
-function getData(dirPath, lang, copyFile, showErrors, dataFrom, options, callback) {
+function getData(dirPath, lang, copyFile, showErrors, dataFrom, options, getDataCB) {
+
+    fs.mkdir(dirPath, err => {
+        if (err && err.errno !== -4075) {
+            console.log(`error: ${err}`);
+        }
+    });
+
     allData = [];
     let req = http.request(options, function(response) {
         let data = '';
@@ -75,7 +82,7 @@ function getData(dirPath, lang, copyFile, showErrors, dataFrom, options, callbac
         });
         response.on('end', function () {
             data = JSON.parse(data);
-            callback(data, dirPath, lang, copyFile, dataFrom, showErrors);
+            getDataCB(data, dirPath, lang, copyFile, dataFrom, showErrors, generateYaml);
         });
     }).end();
 }
@@ -135,12 +142,15 @@ function rueten(obj, lang) {
 }
 
 
-function getDataCB(data, dirPath, lang, copyFile, dataFrom, showErrors) {
+function getDataCB(data, dirPath, lang, copyFile, dataFrom, showErrors, generateYaml) {
     allData = [];
     // data = rueten(data, lang);
     // console.log(data);
     data.forEach(element => {
         let slugEn = element.slug_en;
+        if (!slugEn) {
+            slugEn = element.slug_et;
+        }
 
         // rueten func. is run for each element separately instead of whole data, that is
         // for the purpose of saving slug_en before it will be removed by rueten func.
@@ -152,47 +162,48 @@ function getDataCB(data, dirPath, lang, copyFile, dataFrom, showErrors) {
 
         if(element.directory) {
             fs.mkdir(element.directory, err => {
-                if (err) {
+                if (err && err.errno !== -4075) {
+                    console.log(err);
+                }else{
+                                        // let element = JSON.parse(JSON.stringify(element));
+                    // let aliases = []
+                    let languageKeys = ['en', 'et', 'ru'];
+                    for (key in element) {
+                        let lastThree = key.substring(key.length - 3, key.length);
+                        let findHyphen = key.substring(key.length - 3, key.length - 2);
+                        // if (lastThree !== `_${lang}` && findHyphen === '_' && !allLanguages.includes(lastThree)) {
+                        //     if (key.substring(0, key.length - 3) == 'slug') {
+                        //         aliases.push(element[key]);
+                        //     }
+                        //     delete element[key];
+                        // }
+                        // if (lastThree === `_${lang}`) {
+                        if (key == 'slug') {
+                            element.path = `film/${element[key]}`;
+                        }
+                            // element[key.substring(0, key.length - 3)] = element[key];
+
+
+                        // delete element[key];
+                        // }
+
+                        // Make separate CSV with key
+
+                        if (typeof(element[key]) === 'object' && element[key] != null) {
+                            // makeCSV(element[key], element, lang);
+                        }
+
+                    }
+
+
+
+                    // element.aliases = aliases;
+                    // rueten(element, `_${lang}`);
+                    allData.push(element);
+                    element.data = dataFrom;
+                    generateYaml(element, element, dirPath, lang, copyFile)
                 }
             });
-
-            // let element = JSON.parse(JSON.stringify(element));
-            // let aliases = []
-            let languageKeys = ['en', 'et', 'ru'];
-            for (key in element) {
-                let lastThree = key.substring(key.length - 3, key.length);
-                let findHyphen = key.substring(key.length - 3, key.length - 2);
-                // if (lastThree !== `_${lang}` && findHyphen === '_' && !allLanguages.includes(lastThree)) {
-                //     if (key.substring(0, key.length - 3) == 'slug') {
-                //         aliases.push(element[key]);
-                //     }
-                //     delete element[key];
-                // }
-                // if (lastThree === `_${lang}`) {
-                if (key == 'slug') {
-                    element.path = `film/${element[key]}`;
-                }
-                    // element[key.substring(0, key.length - 3)] = element[key];
-
-
-                // delete element[key];
-                // }
-
-                // Make separate CSV with key
-
-                if (typeof(element[key]) === 'object' && element[key] != null) {
-                    // makeCSV(element[key], element, lang);
-                }
-
-            }
-
-
-
-            // element.aliases = aliases;
-            // rueten(element, `_${lang}`);
-            allData.push(element);
-            element.data = dataFrom;
-            generateYaml(element, element, dirPath, lang, copyFile)
         }else{
             if(showErrors) {
                 console.log(`Film ID ${element.id} slug_en value missing`);

--- a/source/films.et.yaml
+++ b/source/films.et.yaml
@@ -121,7 +121,7 @@
                 name: Pärsia
     title: 'Yalda, andestuse öö'
     slug: yalda-andestuse-oo
-    directory: source/_fetchdir/films_poff//yalda-a-night-for-forgiveness
+    directory: source/_fetchdir/films_poff/yalda-a-night-for-forgiveness
     path: film/yalda-andestuse-oo
     data:
         pictures: /film_pictures.yaml
@@ -215,7 +215,7 @@
                 name: Inglise
     title: Maudie
     slug: maudie
-    directory: source/_fetchdir/films_poff//maudie
+    directory: source/_fetchdir/films_poff/maudie
     path: film/maudie
     data:
         pictures: /film_pictures.yaml
@@ -306,7 +306,7 @@
                 name: Inglise
     title: 'Tagaotsitav: Banksy!'
     slug: tagaotsitav-banksy
-    directory: source/_fetchdir/films_poff//banksy-most-wanted
+    directory: source/_fetchdir/films_poff/banksy-most-wanted
     path: film/tagaotsitav-banksy
     data:
         pictures: /film_pictures.yaml
@@ -417,7 +417,7 @@
                 name: Inglise
     title: 'Acasă, mu kodu'
     slug: acasa-mu-kodu
-    directory: source/_fetchdir/films_poff//acasa-my-home
+    directory: source/_fetchdir/films_poff/acasa-my-home
     path: film/acasa-mu-kodu
     data:
         pictures: /film_pictures.yaml
@@ -501,7 +501,7 @@
                 name: Inglise
     title: Tormipoiss
     slug: tormipoiss
-    directory: source/_fetchdir/films_poff//storm-boy
+    directory: source/_fetchdir/films_poff/storm-boy
     path: film/tormipoiss
     data:
         pictures: /film_pictures.yaml
@@ -599,7 +599,7 @@
                 name: Portugali
     title: Nähtamatu elu
     slug: nahtamatu-elu
-    directory: source/_fetchdir/films_poff//invisible-life-of-euridice-gusmao
+    directory: source/_fetchdir/films_poff/invisible-life-of-euridice-gusmao
     path: film/nahtamatu-elu
     data:
         pictures: /film_pictures.yaml
@@ -686,7 +686,7 @@
                 name: Korea
     title: Hüvasti!
     slug: huvasti
-    directory: source/_fetchdir/films_poff//house-of-hummingbird
+    directory: source/_fetchdir/films_poff/house-of-hummingbird
     path: film/huvasti
     data:
         pictures: /film_pictures.yaml
@@ -798,7 +798,7 @@
                 name: Vene
     title: Täiuslik
     slug: taiuslik
-    directory: source/_fetchdir/films_poff//flawless
+    directory: source/_fetchdir/films_poff/flawless
     path: film/taiuslik
     data:
         pictures: /film_pictures.yaml
@@ -886,7 +886,7 @@
                 name: Itaalia
     title: Õnnejumalanna
     slug: onnejumalanna
-    directory: source/_fetchdir/films_poff//the-goddess-of-fortune
+    directory: source/_fetchdir/films_poff/the-goddess-of-fortune
     path: film/onnejumalanna
     data:
         pictures: /film_pictures.yaml
@@ -974,7 +974,7 @@
                 name: Eesti
     title: Lammas all paremas nurgas
     slug: lammas-all-paremas-nurgas
-    directory: source/_fetchdir/films_poff//the-secret-lamb
+    directory: source/_fetchdir/films_poff/the-secret-lamb
     path: film/lammas-all-paremas-nurgas
     data:
         pictures: /film_pictures.yaml
@@ -1059,7 +1059,7 @@
                 name: Hispaania
     title: Tšempionid
     slug: tsempionid
-    directory: source/_fetchdir/films_poff//champions
+    directory: source/_fetchdir/films_poff/champions
     path: film/tsempionid
     data:
         pictures: /film_pictures.yaml
@@ -1148,7 +1148,7 @@
                 name: Inglise
     title: Skeemitajad
     slug: skeemitajad
-    directory: source/_fetchdir/films_poff//schemers
+    directory: source/_fetchdir/films_poff/schemers
     path: film/skeemitajad
     data:
         pictures: /film_pictures.yaml
@@ -1244,7 +1244,7 @@
                 name: Inglise
     title: Marcel Duchamp ja võimalikkuse kunst
     slug: marcel-duchamp-ja-voimalikkuse-kunst
-    directory: source/_fetchdir/films_poff//marcel-duchamp-art-of-the-possible
+    directory: source/_fetchdir/films_poff/marcel-duchamp-art-of-the-possible
     path: film/marcel-duchamp-ja-voimalikkuse-kunst
     data:
         pictures: /film_pictures.yaml
@@ -1325,7 +1325,7 @@
                 name: Vene
     title: Hape
     slug: hape
-    directory: source/_fetchdir/films_poff//acid
+    directory: source/_fetchdir/films_poff/acid
     path: film/hape
     data:
         pictures: /film_pictures.yaml
@@ -1428,7 +1428,7 @@
                 name: Prantsuse
     title: Viimane portree
     slug: viimane-portree
-    directory: source/_fetchdir/films_poff//final-portrait
+    directory: source/_fetchdir/films_poff/final-portrait
     path: film/viimane-portree
     data:
         pictures: /film_pictures.yaml
@@ -1528,7 +1528,7 @@
                 name: Soome
     title: Harjumuse jõud
     slug: harjumuse-joud
-    directory: source/_fetchdir/films_poff//force-of-habit
+    directory: source/_fetchdir/films_poff/force-of-habit
     path: film/harjumuse-joud
     data:
         pictures: /film_pictures.yaml
@@ -1614,7 +1614,7 @@
                 name: Norwegian
     title: Autoportree
     slug: autoportree
-    directory: source/_fetchdir/films_poff//self-portrait
+    directory: source/_fetchdir/films_poff/self-portrait
     path: film/autoportree
     data:
         pictures: /film_pictures.yaml

--- a/source/films.ru.yaml
+++ b/source/films.ru.yaml
@@ -102,7 +102,7 @@
                 name: Персидский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//yalda-a-night-for-forgiveness
+    directory: source/_fetchdir/films_poff/yalda-a-night-for-forgiveness
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -181,7 +181,7 @@
                 name: Английский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//maudie
+    directory: source/_fetchdir/films_poff/maudie
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -251,7 +251,7 @@
                 name: Английский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//banksy-most-wanted
+    directory: source/_fetchdir/films_poff/banksy-most-wanted
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -340,7 +340,7 @@
                 name: Английский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//acasa-my-home
+    directory: source/_fetchdir/films_poff/acasa-my-home
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -411,7 +411,7 @@
                 name: Английский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//storm-boy
+    directory: source/_fetchdir/films_poff/storm-boy
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -496,7 +496,7 @@
                 name: Португальский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//invisible-life-of-euridice-gusmao
+    directory: source/_fetchdir/films_poff/invisible-life-of-euridice-gusmao
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -567,7 +567,7 @@
                 name: Корейский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//house-of-hummingbird
+    directory: source/_fetchdir/films_poff/house-of-hummingbird
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -664,80 +664,7 @@
                 name: Русский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//flawless
-    path: film/
-    data:
-        pictures: /film_pictures.yaml
-        screenings: /film/screenings.ru.yaml
--
-    id: 506
-    updated_by:
-        id: 1
-        firstname: Mihkel
-        lastname: Putrinš
-    created_at: '2020-08-19T08:36:37.102Z'
-    updated_at: '2020-08-28T09:01:48.953Z'
-    title_et: Õnnejumalanna
-    title_en: The Goddess of Fortune
-    titleOriginal: La dea fortuna
-    year: 2019
-    runtime: 114
-    slug_et: onnejumalanna
-    slug_en: the-goddess-of-fortune
-    filmId: '1004'
-    credentials:
-        id: 387
-        director:
-            - Ferzan Özpetek
-        screenwriter:
-            - Ferzan Özpetek
-            - ' Silvia Ranfagni'
-            - ' Gianni Romoli'
-        doP:
-            - Gian Filippo Corticelli
-        cast:
-            - Stefano Accorsi
-            - ' Jasmine Trinca'
-            - ' Edoardo Leo'
-        composer:
-            - Pasquale Catalano
-    synopsis: ''
-    media:
-        id: 322
-        Trailer:
-            -
-                id: 307
-                Url: ''
-                Source: ''
-        QaClip:
-            -
-                id: 303
-                Url: ''
-    tags:
-        id: 310
-    countriesAndLanguages:
-        id: 294
-        countries:
-            -
-                id: 936
-                created_at: '2020-08-17T14:20:49.557Z'
-                updated_at: '2020-08-17T14:20:49.557Z'
-                code: IT
-                name_et: Itaalia
-                name_en: Italy
-                name: Италия
-        languages:
-            -
-                id: 1709
-                created_at: '2020-08-24T12:28:26.804Z'
-                updated_at: '2020-08-24T12:28:26.804Z'
-                name_et: Itaalia
-                name_en: Italian
-                code: it
-                name: Итальянский
-    title: ''
-    slug: ''
-    directory: source/_fetchdir/films_poff//the-goddess-of-fortune
+    directory: source/_fetchdir/films_poff/flawless
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -811,7 +738,80 @@
                 name: Эстонский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//the-secret-lamb
+    directory: source/_fetchdir/films_poff/the-secret-lamb
+    path: film/
+    data:
+        pictures: /film_pictures.yaml
+        screenings: /film/screenings.ru.yaml
+-
+    id: 506
+    updated_by:
+        id: 1
+        firstname: Mihkel
+        lastname: Putrinš
+    created_at: '2020-08-19T08:36:37.102Z'
+    updated_at: '2020-08-28T09:01:48.953Z'
+    title_et: Õnnejumalanna
+    title_en: The Goddess of Fortune
+    titleOriginal: La dea fortuna
+    year: 2019
+    runtime: 114
+    slug_et: onnejumalanna
+    slug_en: the-goddess-of-fortune
+    filmId: '1004'
+    credentials:
+        id: 387
+        director:
+            - Ferzan Özpetek
+        screenwriter:
+            - Ferzan Özpetek
+            - ' Silvia Ranfagni'
+            - ' Gianni Romoli'
+        doP:
+            - Gian Filippo Corticelli
+        cast:
+            - Stefano Accorsi
+            - ' Jasmine Trinca'
+            - ' Edoardo Leo'
+        composer:
+            - Pasquale Catalano
+    synopsis: ''
+    media:
+        id: 322
+        Trailer:
+            -
+                id: 307
+                Url: ''
+                Source: ''
+        QaClip:
+            -
+                id: 303
+                Url: ''
+    tags:
+        id: 310
+    countriesAndLanguages:
+        id: 294
+        countries:
+            -
+                id: 936
+                created_at: '2020-08-17T14:20:49.557Z'
+                updated_at: '2020-08-17T14:20:49.557Z'
+                code: IT
+                name_et: Itaalia
+                name_en: Italy
+                name: Италия
+        languages:
+            -
+                id: 1709
+                created_at: '2020-08-24T12:28:26.804Z'
+                updated_at: '2020-08-24T12:28:26.804Z'
+                name_et: Itaalia
+                name_en: Italian
+                code: it
+                name: Итальянский
+    title: ''
+    slug: ''
+    directory: source/_fetchdir/films_poff/the-goddess-of-fortune
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -883,7 +883,7 @@
                 name: Испанский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//champions
+    directory: source/_fetchdir/films_poff/champions
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -953,7 +953,7 @@
                 name: Английский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//schemers
+    directory: source/_fetchdir/films_poff/schemers
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -1026,7 +1026,7 @@
                 name: Английский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//marcel-duchamp-art-of-the-possible
+    directory: source/_fetchdir/films_poff/marcel-duchamp-art-of-the-possible
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -1095,7 +1095,7 @@
                 name: Русский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//acid
+    directory: source/_fetchdir/films_poff/acid
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -1182,7 +1182,7 @@
                 name: Французский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//final-portrait
+    directory: source/_fetchdir/films_poff/final-portrait
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -1263,7 +1263,7 @@
                 name: Финский
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//force-of-habit
+    directory: source/_fetchdir/films_poff/force-of-habit
     path: film/
     data:
         pictures: /film_pictures.yaml
@@ -1330,7 +1330,7 @@
                 name: Нюнорск (новонорвежский)
     title: ''
     slug: ''
-    directory: source/_fetchdir/films_poff//self-portrait
+    directory: source/_fetchdir/films_poff/self-portrait
     path: film/
     data:
         pictures: /film_pictures.yaml


### PR DESCRIPTION
Enne pidi vahel mitu korda jooksutama, sest kataloogide loomise ja faili kirjutamisega tegeles script ühel ajal - st vahel ei jõutud kataloogi enne faili kirjutamist luua mis andis errori.

Nüüd peaks teoorias korras olema.